### PR TITLE
[Feat] 메인페이지 초기 UI 구현

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,10 +1,37 @@
+/* App.css */
+
+/* #root는 전체 화면을 차지하는 기본 컨테이너 역할만 합니다. */
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  display: flex; /* 자식 요소(AppLayout의 div)가 flex 아이템으로 동작하도록 */
+  flex-direction: column; /* 자식 요소가 수직으로 쌓이도록 */
+  min-height: 100vh; /* 최소 화면 전체 높이 */
+  width: 100%; /* 화면 전체 너비 */
 }
 
+/* 다른 페이지들 (로그인, 회원가입 등)을 위한 기본 레이아웃 클래스 */
+.app-layout-default {
+  width: 100%; /* 부모(#root) 너비 내에서 100%를 차지하려고 시도 */
+  max-width: 1280px; /* 최대 너비 제한 */
+  margin: 0 auto;    /* max-width가 적용될 때 중앙 정렬 */
+  padding: 2rem;     /* 기존 패딩 유지 */
+  text-align: center;  /* 기존 텍스트 정렬 유지 */
+  flex-grow: 1;      /* #root 내에서 남은 수직 공간을 채우도록 */
+  display: flex;       /* 내부 컨텐츠(각 페이지 컴포넌트) 정렬을 위해 */
+  flex-direction: column; /* 내부 컨텐츠를 수직으로 쌓음 */
+}
+
+/* MainPage를 위한 전체 너비 레이아웃 클래스 */
+.app-layout-main {
+  width: 100%;         /* 화면 전체 너비 사용 */
+  padding: 0;          /* MainPage는 자체적으로 패딩 관리 (이전 설정 유지) */
+  margin: 0;
+  text-align: left;    /* MainPage는 왼쪽 정렬을 기본으로 */
+  flex-grow: 1;      /* #root 내에서 남은 수직 공간을 채우도록 */
+  display: flex;       /* 내부 컨텐츠(MainPage 컴포넌트) 정렬을 위해 */
+  flex-direction: column; /* 내부 컨텐츠를 수직으로 쌓음 */
+}
+
+/* --- 기존 App.css의 나머지 스타일들 (.logo, .card 등) --- */
 .logo {
   height: 6em;
   padding: 1.5em;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,22 +1,44 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
-import { BrowserRouter, Route, Routes } from 'react-router-dom'
-import Signup from './pages/signup'
-import Login from './pages/Login'
+import { useState, useEffect } from 'react'; // useEffect 추가
+// import reactLogo from './assets/react.svg';
+// import viteLogo from '/vite.svg';
+import './App.css'; // 수정된 App.css를 import
+import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom';
+import Signup from './pages/signup';
+import Login from './pages/Login';
+import MainPage from './pages/MainPage/MainPage';
 
-function App() {
-  const [count, setCount] = useState(0)
+// 라우트에 따라 다른 레이아웃 클래스를 적용하기 위한 내부 컴포넌트
+function AppLayout() {
+  const location = useLocation();
+  const [layoutClass, setLayoutClass] = useState('app-layout-default'); // 기본 레이아웃
+
+  // location.pathname이 변경될 때마다 적절한 레이아웃 클래스 설정
+  useEffect(() => {
+    if (location.pathname === '/') { // MainPage 경로
+      setLayoutClass('app-layout-main');
+    } else {
+      setLayoutClass('app-layout-default');
+    }
+  }, [location.pathname]); // 경로가 변경될 때만 이 효과를 다시 실행
 
   return (
-    <BrowserRouter>
-    <Routes>
-      <Route path='/users/login' element={<Login/>}/>
-      <Route path='/users/signup' element={<Signup/>}/>
-    </Routes>
-    </BrowserRouter>
-  )
+    // 이 div가 #root 바로 아래의 최상위 wrapper가 되어 레이아웃을 결정합니다.
+    <div className={layoutClass}>
+      <Routes>
+        <Route path='/users/login' element={<Login/>}/>
+        <Route path='/users/signup' element={<Signup/>}/>
+        <Route path='/' element={<MainPage/>}/>
+      </Routes>
+    </div>
+  );
 }
 
-export default App
+function App() {
+  return (
+    <BrowserRouter>
+      <AppLayout />
+    </BrowserRouter>
+  );
+}
+
+export default App;

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import styles from './Footer.module.css';
+
+function Footer() {
+  return (
+    <footer className={styles.footer}>
+      <div className={styles.footerContent}>
+        <div className={styles.brandInfo}>
+          {/* TODO: 로고 아이콘 */}
+          <div className={styles.brandIcon}>🧊</div> {/* 임시 아이콘 */}
+          <span className={styles.brandName}>(가제)취업하기 좋은 날</span>
+        </div>
+        <div className={styles.footerLinks}>
+          {/* TODO: 실제 링크 및 내용으로 변경 */}
+          <p>설명설명</p>
+          <p>연락처 연락처</p>
+          <p>뭐를 사용했습니다</p>
+          {/* <a href="/terms">이용약관</a>
+          <a href="/privacy">개인정보처리방침</a>
+          <a href="/contact">고객센터</a> */}
+        </div>
+      </div>
+      <div className={styles.copyright}>
+        © {new Date().getFullYear()} Your Company Name. All Rights Reserved.
+      </div>
+    </footer>
+  );
+}
+
+export default Footer;

--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -1,0 +1,57 @@
+.footer {
+  box-sizing: border-box; /* 최우선 적용 */
+  background-color: #343a40;
+  color: #adb5bd;
+  padding: 30px 5%; /* 좌우 패딩을 %로 */
+  font-size: 0.9em;
+  width: 100%;
+}
+
+.footerContent {
+  box-sizing: border-box; /* 내부 콘텐츠 영역도 확인 */
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  width: 100%; /* .footer의 padding 안쪽에서 100%를 차지 */
+  margin: 0 auto 20px auto;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+.brandInfo {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0; /* 줄어들지 않도록 */
+}
+
+.brandIcon {
+  font-size: 2.5em;
+  margin-right: 10px;
+  color: #fff;
+}
+
+.brandName {
+  font-size: 1.2em;
+  font-weight: bold;
+  color: #fff;
+  white-space: nowrap; /* 줄바꿈 방지 */
+}
+
+.footerLinks {
+  text-align: right;
+  /* flex-grow: 1; */ /* 필요시 공간 채우도록 */
+}
+
+.footerLinks p {
+  margin: 5px 0;
+  white-space: nowrap; /* 줄바꿈 방지 */
+}
+
+.copyright {
+  text-align: center;
+  font-size: 0.8em;
+  border-top: 1px solid #495057;
+  padding-top: 20px;
+  color: #888;
+  clear: both; /* flex-wrap으로 인해 요소가 엉킬 경우 대비 */
+}

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import styles from './Header.module.css';
+
+function Header() {
+    return (
+        <header className={styles.header}>
+            <div className={styles.logo}>
+                <a href="/">Logo</a> {/* TODO: 로고 이미지 또는 컴포넌트로 교체 /}
+</div>
+<nav className={styles.navigation}>
+<ul>
+<li><a href="/">홈</a></li>
+<li><a href="/news">뉴스</a></li>
+<li><a href="/jobs">채용공고</a></li>
+<li>
+<a href="/link-four">
+Link Four <span className={styles.dropdownArrow}>▼</span> {/ TODO: 실제 드롭다운 아이콘으로 교체 /}
+</a>
+{/ TODO: 드롭다운 메뉴 구현 /}
+</li>
+</ul>
+</nav>
+<div className={styles.userActions}>
+{/ TODO: 사용자 아이콘 (예: react-icons 라이브러리 사용) /}
+<span className={styles.userIcon}>👤</span> {/ 임시 사용자 아이콘 */}
+            </div>
+        </header>
+    );
+}
+
+export default Header;

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,0 +1,48 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px 40px; /* 상하 패딩, 좌우 패딩 (이미지 기반 추정) */
+  background-color: #ffffff;
+  border-bottom: 1px solid #e0e0e0;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  height: 60px; /* 헤더 높이 고정 (예시) */
+}
+
+.logo a {
+  font-size: 1.8em;
+  font-weight: bold;
+  color: #333;
+  text-decoration: none;
+}
+
+.navigation ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 30px; /* 메뉴 간 간격 */
+}
+
+.navigation li a {
+  text-decoration: none;
+  color: #555;
+  font-size: 1em;
+  font-weight: 500;
+  transition: color 0.2s ease-in-out;
+}
+
+.navigation li a:hover {
+  color: #007bff; /* 호버 시 색상 (예시) */
+}
+
+.dropdownArrow {
+  font-size: 0.7em;
+  margin-left: 4px;
+}
+
+.userActions .userIcon {
+  font-size: 1.5em; /* 아이콘 크기 */
+  color: #555;
+  cursor: pointer;
+}

--- a/src/components/JobCard/JobCard.jsx
+++ b/src/components/JobCard/JobCard.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styles from './JobCard.module.css';
+
+function JobCard({ job }) {
+  if (!job) {
+    return null; // job 데이터가 없으면 렌더링하지 않음
+  }
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.categoryTag}>{job.category || "미분류"}</div>
+      <h4 className={styles.title}>{job.title || "제목 없음"}</h4>
+      <p className={styles.description}>{job.description || "설명 없음"}</p>
+      <button className={styles.detailsButton}>
+        Button &gt; {/* TODO: 버튼 텍스트 및 기능 구현 */}
+      </button>
+    </div>
+  );
+}
+
+export default JobCard;

--- a/src/components/JobCard/JobCard.module.css
+++ b/src/components/JobCard/JobCard.module.css
@@ -1,0 +1,72 @@
+.card {
+  background-color: #ffffff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 20px;
+  text-align: left;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.07);
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between; /* 내부 요소들 수직 정렬 */
+  min-height: 220px; /* 카드 최소 높이 */
+
+  /* --- 카드 너비 제어 --- */
+  width: 260px; /* 카드의 기본 너비를 지정 (기존 grid의 minmax(250px, ..) 참고) */
+  /* 또는 flex-basis 사용:
+  flex-basis: 260px;
+  flex-grow: 0;   /* 카드가 남는 공간을 차지하며 늘어나지 않도록 */
+  /* flex-shrink: 0; /* 카드가 공간이 부족할 때 줄어들지 않도록 (필요시 1로 설정하여 줄어들게 할 수도 있음) */
+  /* -------------------- */
+}
+
+.card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.categoryTag {
+  display: inline-block;
+  background-color: #eef4ff; /* 태그 배경색 (이미지 기반 추정) */
+  color: #0056b3; /* 태그 글자색 */
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 0.8em;
+  font-weight: 500;
+  margin-bottom: 12px;
+}
+
+.title {
+  font-size: 1.2em;
+  font-weight: bold;
+  color: #333;
+  margin-top: 0;
+  margin-bottom: 10px;
+  line-height: 1.3;
+}
+
+.description {
+  font-size: 0.9em;
+  color: #666;
+  line-height: 1.5;
+  margin-bottom: 15px;
+  flex-grow: 1;
+}
+
+.detailsButton {
+  background-color: transparent;
+  color: #007bff;
+  border: 1px solid #007bff;
+  padding: 8px 15px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 0.9em;
+  align-self: flex-start;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.detailsButton:hover {
+  background-color: #007bff;
+  color: white;
+}

--- a/src/components/RecommendationSection/RecommendationSection.jsx
+++ b/src/components/RecommendationSection/RecommendationSection.jsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import JobCard from '../JobCard/JobCard';
+// import NewsCard from '../NewsCard/NewsCard'; // 뉴스 카드도 필요시 만듭니다.
+import styles from './RecommendationSection.module.css';
+
+// 임시 데이터 (API로부터 받아올 데이터)
+const dummyJobPostings = [
+  { id: 1, category: "금융권 IT", title: "IBK기업은행 체험형..", description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
+  { id: 2, category: "대기업 SI", title: "삼성SDS ...", description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
+  { id: 3, category: "대기업 SI", title: "CJ그룹 ...", description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
+  { id: 4, category: "부트캠프", title: "LG CNS AM ...", description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
+  { id: 5, category: "금융권 IT", title: "다른 IBK 공고", description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
+  { id: 6, category: "대기업 SI", title: "다른 삼성 공고", description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
+  { id: 7, category: "대기업 SI", title: "다른 CJ 공고", description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
+  { id: 8, category: "부트캠프", title: "다른 LG 공고", description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
+  { id: 9, category: "스타트업", title: "새로운 회사 공고 1", description: "새로운 설명입니다. 다음 페이지 내용입니다." },
+  { id: 10, category: "스타트업", title: "새로운 회사 공고 2", description: "새로운 설명입니다." },
+  { id: 11, category: "중견기업", title: "새로운 회사 공고 3", description: "새로운 설명입니다." },
+  { id: 12, category: "중견기업", title: "새로운 회사 공고 4", description: "새로운 설명입니다." },
+];
+
+// 임시 뉴스 데이터 (필요시)
+// const dummyNewsItems = [ ... ];
+
+const ITEMS_PER_PAGE = 4; // 한 페이지에 보여줄 카드 수를 4로 변경!
+
+function RecommendationSection() {
+  const [activeTab, setActiveTab] = useState('jobs'); // 'jobs' or 'news'
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // 현재 탭에 따라 보여줄 데이터 선택
+  const currentData = activeTab === 'jobs' ? dummyJobPostings : []; // TODO: 뉴스 데이터 추가
+  const totalPages = Math.ceil(currentData.length / ITEMS_PER_PAGE);
+
+  // 현재 페이지에 보여줄 아이템들
+  const paginatedData = currentData.slice(
+    (currentPage - 1) * ITEMS_PER_PAGE,
+    currentPage * ITEMS_PER_PAGE
+  );
+
+  const handleTabClick = (tabName) => {
+    setActiveTab(tabName);
+    setCurrentPage(1); // 탭 변경 시 첫 페이지로
+  };
+
+  const handlePrevPage = () => {
+    setCurrentPage((prev) => Math.max(prev - 1, 1));
+  };
+
+  const handleNextPage = () => {
+    setCurrentPage((prev) => Math.min(prev + 1, totalPages));
+  };
+
+  return (
+    <section className={styles.recommendationSection}>
+      <h3 className={styles.sectionTitle}>
+        {/* TODO: 사용자 이름 동적으로 변경 */}
+        OOO님을 위한 소식을 확인하세요
+      </h3>
+      <div className={styles.tabContainer}>
+        <button
+          className={`${styles.tabButton} ${activeTab === 'jobs' ? styles.active : ''}`}
+          onClick={() => handleTabClick('jobs')}
+        >
+          채용공고
+        </button>
+        <button
+          className={`${styles.tabButton} ${activeTab === 'news' ? styles.active : ''}`}
+          onClick={() => handleTabClick('news')}
+        >
+          뉴스
+        </button>
+      </div>
+
+      <div className={styles.contentGrid}>
+        {activeTab === 'jobs' && paginatedData.length > 0 && paginatedData.map(job => (
+          <JobCard key={job.id} job={job} />
+        ))}
+        {activeTab === 'jobs' && paginatedData.length === 0 && <p className={styles.emptyMessage}>표시할 채용 공고가 없습니다.</p>}
+        {/* TODO: 뉴스 탭 선택 시 뉴스 카드 렌더링 */}
+        {activeTab === 'news' && <p className={styles.emptyMessage}>뉴스 정보가 곧 제공될 예정입니다.</p>}
+      </div>
+
+      {currentData.length > ITEMS_PER_PAGE && (
+        <div className={styles.paginationControls}>
+          <div className={styles.pageIndicators}>
+            {[...Array(totalPages)].map((_, index) => (
+              <span
+                key={index}
+                className={`${styles.dot} ${currentPage === index + 1 ? styles.activeDot : ''}`}
+                onClick={() => setCurrentPage(index + 1)} // 점 클릭으로 페이지 이동
+              ></span>
+            ))}
+          </div>
+          <div className={styles.arrowButtons}>
+            <button onClick={handlePrevPage} disabled={currentPage === 1} className={styles.arrowButton}>
+              &lt; {/* TODO: 왼쪽 화살표 아이콘 */}
+            </button>
+            <button onClick={handleNextPage} disabled={currentPage === totalPages} className={styles.arrowButton}>
+              &gt; {/* TODO: 오른쪽 화살표 아이콘 */}
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default RecommendationSection;

--- a/src/components/RecommendationSection/RecommendationSection.module.css
+++ b/src/components/RecommendationSection/RecommendationSection.module.css
@@ -1,0 +1,135 @@
+.recommendationSection {
+  box-sizing: border-box;
+  padding: 40px 5%;
+  width: 100%;
+  margin: 20px 0;
+  text-align: center;
+}
+
+.sectionTitle {
+  box-sizing: border-box;
+  font-size: clamp(1.5em, 3vw, 1.8em);
+  font-weight: bold;
+  color: #333;
+  margin-bottom: 30px;
+}
+
+.tabContainer {
+  box-sizing: border-box;
+  margin-bottom: 30px;
+  display: flex;
+  justify-content: center;
+  gap: 0;
+}
+
+.tabButton {
+  padding: 10px 30px;
+  font-size: clamp(1em, 2vw, 1.1em);
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid #ccc;
+  background-color: #f9f9f9;
+  color: #555;
+  transition: background-color 0.2s, color 0.2s;
+  border-radius: 0;
+}
+
+.tabButton:first-child {
+  border-top-left-radius: 5px;
+  border-bottom-left-radius: 5px;
+}
+.tabButton:last-child {
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
+  border-left-width: 0;
+}
+
+.tabButton.active {
+  background-color: #007bff;
+  color: white;
+  border-color: #007bff;
+}
+
+.tabButton:hover:not(.active) {
+  background-color: #e9e9e9;
+}
+
+.contentGrid {
+  box-sizing: border-box;
+  display: flex; /* Grid 대신 Flexbox 사용 */
+  justify-content: center; /* 아이템들을 수평 중앙 정렬 */
+  flex-wrap: wrap; /* 화면이 매우 좁을 경우 아이템들이 다음 줄로 넘어가도록 (선택적) */
+  gap: 20px; /* 아이템들 사이의 간격 */
+  margin-bottom: 30px;
+  padding: 0 10px; /* 좌우 약간의 여백을 주어 너무 붙지 않게 (선택적) */
+  min-height: 280px; /* 기존 최소 높이 유지 */
+}
+
+.emptyMessage {
+  /* grid-column: 1 / -1; /* Flexbox에서는 이 속성이 필요 없음 */
+  width: 100%; /* Flex 컨테이너 내에서 전체 너비를 차지하도록 */
+  text-align: center;
+  color: #777;
+  font-size: 1.1em;
+  padding: 50px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: inherit;
+}
+
+.paginationControls {
+  box-sizing: border-box;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 30px;
+  padding: 0 20px;
+}
+
+.pageIndicators {
+  display: flex;
+  gap: 8px;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  background-color: #ccc;
+  border-radius: 50%;
+  transition: background-color 0.2s;
+  cursor: pointer;
+}
+
+.dot.activeDot {
+  background-color: #007bff;
+}
+
+.arrowButtons {
+  display: flex;
+  gap: 10px;
+}
+
+.arrowButton {
+  background-color: #fff;
+  border: 1px solid #ccc;
+  color: #333;
+  padding: 8px 12px;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1;
+  transition: background-color 0.2s, border-color 0.2s;
+  width: 36px;
+  height: 36px;
+}
+
+.arrowButton:hover:not(:disabled) {
+  background-color: #f0f0f0;
+  border-color: #bbb;
+}
+
+.arrowButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/components/Weather/Weather.jsx
+++ b/src/components/Weather/Weather.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import styles from './Weather.module.css';
+
+function Weather() {
+  // TODO: 이 데이터는 API로부터 받아와야 합니다.
+  const weatherData = {
+    conditionText: "맑음",
+    temperature: 25, // 실제 온도가 아닌 채용 지수
+    comment1: "어제보다 4°C 높아요.",
+    comment2: "신입 개발자 채용이 00건 추가됐어요.",
+    comment3: "앞으로 화창한 날씨가 계속되길 기대해요.",
+    lastUpdated: "2025. 05. 16. 06:00" // 이미지의 업데이트 시간
+  };
+
+  return (
+    <section className={styles.weatherSection}>
+      <div className={styles.weatherVisual}>
+        {/* TODO: 실제 해 아이콘 (예: react-icons의 WiDaySunny) */}
+        <div className={styles.sunIcon}>☀️</div>
+        <div className={styles.temperatureBox}>
+          {weatherData.temperature}°C
+        </div>
+      </div>
+      <div className={styles.weatherInfo}>
+        <h2 className={styles.title}>
+          오늘의 채용 날씨는 '<span className={styles.condition}>{weatherData.conditionText}</span>' !
+        </h2>
+        <ul className={styles.comments}>
+          <li>{weatherData.comment1}</li>
+          <li>{weatherData.comment2}</li>
+          <li>{weatherData.comment3}</li>
+        </ul>
+        <p className={styles.lastUpdated}>
+          업데이트 : {weatherData.lastUpdated}
+        </p>
+      </div>
+    </section>
+  );
+}
+
+export default Weather;

--- a/src/components/Weather/Weather.module.css
+++ b/src/components/Weather/Weather.module.css
@@ -1,0 +1,77 @@
+.weatherSection {
+  box-sizing: border-box; /* 최우선 적용 */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 50px; /* 자식 요소(.weatherVisual, .weatherInfo) 사이의 간격 */
+  background-color: #ffffff;
+  padding: 40px 5%; /* 좌우 패딩을 %로 주어 반응형으로 */
+  margin: 20px 0;
+  width: 100%;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.weatherVisual {
+  /* margin-right: 50px; */ /* 삭제하고 부모의 gap으로 대체 */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-shrink: 0; /* 내용이 많아도 줄어들지 않도록 (아이콘 영역 고정) */
+}
+
+.sunIcon {
+  font-size: clamp(5em, 10vw, 7em);
+  color: #ffcc00;
+  line-height: 1;
+  margin-bottom: 10px;
+}
+
+.temperatureBox {
+  background-color: #007bff;
+  color: white;
+  padding: 8px 15px;
+  border-radius: 20px;
+  font-size: clamp(1.2em, 2.5vw, 1.5em);
+  font-weight: bold;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.weatherInfo {
+  box-sizing: border-box; /* 내부 요소도 확인 */
+  text-align: left;
+  max-width: 600px; /* 텍스트 정보 영역이 너무 넓어지지 않도록 제한 */
+  flex-grow: 1; /* 남은 공간을 차지하도록 시도 */
+}
+
+.title {
+  font-size: clamp(1.5em, 3vw, 2em);
+  font-weight: bold;
+  color: #333;
+  margin-top: 0;
+  margin-bottom: 20px;
+  word-break: keep-all; /* 줄바꿈 단위 개선 */
+}
+
+.title .condition {
+  color: #007bff;
+}
+
+.comments {
+  list-style: disc;
+  padding-left: 20px;
+  margin-bottom: 20px;
+  color: #555;
+  font-size: clamp(0.9em, 1.8vw, 0.95em);
+  line-height: 1.6;
+}
+
+.comments li {
+  margin-bottom: 8px;
+}
+
+.lastUpdated {
+  font-size: clamp(0.8em, 1.5vw, 0.85em);
+  color: #777;
+  text-align: right;
+  word-break: keep-all;
+}

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Header from '../../components/Header/Header';
+import Weather from '../../components/Weather/Weather';
+import RecommendationSection from '../../components/RecommendationSection/RecommendationSection';
+import Footer from '../../components/Footer/Footer';
+import styles from './MainPage.module.css';
+
+function MainPage() {
+  return (
+    <div className={styles.mainPageContainer}>
+      <Header />
+      <main className={styles.mainContent}>
+        <Weather />
+        <RecommendationSection />
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+export default MainPage;

--- a/src/pages/MainPage/Mainpage.module.css
+++ b/src/pages/MainPage/Mainpage.module.css
@@ -1,0 +1,12 @@
+.mainPageContainer {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background-color: #f4f6f8; /* 전체 페이지 배경색 */
+}
+
+.mainContent {
+  flex-grow: 1;
+  width: 100%; /* 화면 너비를 채우도록 */
+  /* padding: 20px; /* 전체적인 패딩이 필요하다면 여기에, 아니면 각 섹션에서 관리 */
+}


### PR DESCRIPTION
##  🚀 작업한 기능 설명 (Feature Description)
- #4
- 사용자가 서비스에 처음 접속했을 때 보게 될 화면입니다.

## 🔍 작업 상세 (Implementation Details)
### 1. 신규 컴포넌트 추가 (메인 페이지 구성 요소)

-   `pages/MainPage/MainPage.jsx`: 메인 페이지 전체 레이아웃 및 컴포넌트 조립
-   `components/Header/Header.jsx`: 상단 네비게이션 바 (우선 **메인페이지로 연결되는 로고만 구현해 둔 상태**입니다.)
-   `components/Weather/Weather.jsx`: '오늘의 채용 날씨' 표시 섹션
-   `components/RecommendationSection/RecommendationSection.jsx`: '추천 채용 정보/뉴스' 섹션 (탭, 카드 목록, 페이지네이션 포함)
-   `components/JobCard/JobCard.jsx`: 채용 정보 카드 UI
-   `components/Footer/Footer.jsx`: 하단 푸터 영역
-   각 컴포넌트별 CSS Modules 파일 (`*.module.css`) 추가

### 2. 기존 코드 변경 사항

-   **`App.jsx` 수정:**
    -   `useLocation` 훅과 `useEffect`를 사용하여 현재 경로에 따라 다른 레이아웃 클래스를 적용하는 `AppLayout` 내부 컴포넌트를 추가했습니다. 이를 통해 `MainPage`는 전체 너비 레이아웃을, 기존 다른 페이지(로그인, 회원가입 등)는 중앙 정렬 레이아웃을 유지하도록 수정했습니다.

-   **`App.css` 수정:**
    -   기존 `#root`에 적용되던 레이아웃 스타일(최대 너비, 중앙 정렬 등)을 클래스 기반으로 분리했습니다.
    -   `.app-layout-default` 클래스: 기존 페이지들을 위한 중앙 정렬 레이아웃
    -   `.app-layout-main` 클래스: `MainPage`를 위한 전체 너비 레이아웃
    -   `#root` 자체는 최소한의 flex 컨테이너 역할만 하도록 변경하여, 위 두 클래스가 적용된 자식 요소가 화면을 올바르게 채울 수 있도록 수정했습니다.
  
## 🖼️ 이미지 첨부 (Images)
![localhost_5173_ (3)](https://github.com/user-attachments/assets/34f93a5b-278f-4961-80ae-149bf8f56237)

화면에 표시되는 모든 컨텐츠는 더미데이터입니다.
