### PR TITLE
[Feat] 스크랩 영역 구현

### DIFF
--- a/src/api/mypage_api.js
+++ b/src/api/mypage_api.js
@@ -29,3 +29,36 @@ export const updateProfile = async (data) => {
 
   return res;
 };
+
+// Liked
+export const getLikedItem = async (item) => {
+  const url = `${MYPAGE_URL}/liked/${item}`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+  const data = await res.json();
+
+  return data;
+};
+
+export const unLikedItem = async (item, itemId) => {
+  const url = `${MYPAGE_URL}/unliked/${item}/${itemId}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+
+  if (!res.ok) {
+    const error = await res.text();
+    throw new Error(`스크랩 취소 실패: ${error}`);
+  }
+
+  return await res.text();
+};

--- a/src/components/Liked/Liked.jsx
+++ b/src/components/Liked/Liked.jsx
@@ -1,0 +1,101 @@
+import TabMenu from "./TabMenu";
+import LikedItem from "./LikedItem";
+import styles from "./Liked.module.css";
+import { useEffect, useState } from "react";
+import { getLikedItem, unLikedItem } from "../../api/mypage_api";
+
+const Liked = () => {
+  const [activeTab, setActiveTab] = useState("emp");
+  const [likedItems, setLikedItems] = useState([]);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // 스크랩한 데이터 출력
+  useEffect(() => {
+    const fetchData = async () => {
+      const res = await getLikedItem(activeTab);
+      setLikedItems(res);
+      setCurrentPage(1);
+    };
+    fetchData();
+  }, [activeTab]);
+
+  // 스크랩 취소
+  const handleUnLike = async (id) => {
+    console.log("handleUnLike's item.id", id);
+    await unLikedItem(activeTab, id);
+    setLikedItems((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  // Pagenation을 위한 설정
+  let page_item = 3;
+  const totalPages = Math.ceil(likedItems.length / page_item);
+  const paginatedData = likedItems.slice(
+    (currentPage - 1) * page_item,
+    currentPage * page_item
+  );
+
+  // 화살표로 페이지 넘기기
+  // const handlePrevPage = () => {
+  //   setCurrentPage((prev) => Math.max(prev - 1, 1));
+  // };
+
+  // const handleNextPage = () => {
+  //   setCurrentPage((prev) => Math.min(prev + 1, totalPages));
+  // };
+
+  const handleTabClick = (tabName) => {
+    setActiveTab(tabName);
+    setCurrentPage(1);
+  };
+
+  return (
+    <section className={styles.likedSection}>
+      <TabMenu activeTab={activeTab} onTabClick={handleTabClick}></TabMenu>
+      <div className={styles.contentGrid}>
+        {likedItems.length == 0 ? (
+          <p className={styles.emptyMessage}>스크랩된 채용공고가 없습니다</p>
+        ) : (
+          <LikedItem
+            data={paginatedData}
+            onUnLike={handleUnLike}
+            type={activeTab}
+          ></LikedItem>
+        )}
+      </div>
+
+      {likedItems.length > page_item && (
+        <div className={styles.paginationControls}>
+          <div className={styles.pageIndicators}>
+            {[...Array(totalPages)].map((_, index) => (
+              <span
+                key={index}
+                className={`${styles.dot} ${
+                  currentPage === index + 1 ? styles.activeDot : ""
+                }`}
+                onClick={() => setCurrentPage(index + 1)} // 점 클릭으로 페이지 이동
+              ></span>
+            ))}
+          </div>
+          {/* <div className={styles.arrowButtons}>
+            <button
+              onClick={handlePrevPage}
+              disabled={currentPage === 1}
+              className={styles.arrowButton}
+            >
+              &lt; 
+            </button>
+            <button
+              onClick={handleNextPage}
+              disabled={currentPage === totalPages}
+              className={styles.arrowButton}
+            >
+              &gt; 
+            </button>
+          </div> */}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default Liked;

--- a/src/components/Liked/Liked.module.css
+++ b/src/components/Liked/Liked.module.css
@@ -1,0 +1,58 @@
+.likedSection {
+  box-sizing: border-box;
+  padding: 40px 5%;
+  width: 100%;
+  margin: 20px 0;
+  text-align: center;
+}
+
+.contentGrid {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 20px; /* 메인페이지 gap과 동일하게 맞춤 */
+  max-width: 1200px;
+  margin-bottom: 30px;
+  padding: 0 10px; /* 메인페이지 padding과 맞춤 */
+  min-height: 280px;
+}
+
+.emptyMessage {
+  /* grid-column: 1 / -1; /* Flexbox에서는 이 속성이 필요 없음 */
+  width: 100%; /* Flex 컨테이너 내에서 전체 너비를 차지하도록 */
+  text-align: center;
+  color: #777;
+  font-size: 1.1em;
+  padding: 50px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: inherit;
+}
+
+.paginationControls {
+  box-sizing: border-box;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 30px;
+  padding: 0 20px;
+}
+
+.pageIndicators {
+  display: flex;
+  gap: 8px;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  background-color: #ccc;
+  border-radius: 50%;
+  transition: background-color 0.2s;
+  cursor: pointer;
+}
+
+.dot.activeDot {
+  background-color: #007bff;
+}

--- a/src/components/Liked/LikedItem.jsx
+++ b/src/components/Liked/LikedItem.jsx
@@ -1,0 +1,45 @@
+import styles from "./LikedItem.module.css";
+
+const LikedItem = ({ data, onUnLike, type }) => {
+  return data.map((item) => (
+    <div className={styles.card} key={item.id}>
+      {console.log(item)}
+      {type === "news" ? (
+        <>
+          <a href={item.url}>
+            <h3 className={styles.title}>{item.title}</h3>
+          </a>
+          <p className={styles.description}>{item.description}</p>
+          <p className={styles.date}>{item.date.split("T")[0]}</p>
+        </>
+      ) : (
+        <>
+          <p className={styles.company}>{item.company}</p>
+          <a href={item.url}>
+            <h3 className={styles.title}>{item.title}</h3>
+          </a>
+          <p className={styles.description}>{item.position}</p>
+          <p className={styles.date}>{item.deadline}</p>
+        </>
+      )}
+      <div className={styles.starContainer}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          fill="gold"
+          class="bi bi-star-fill"
+          viewBox="0 0 16 16"
+          onClick={() => {
+            console.log(item.id);
+            onUnLike(item.id);
+          }}
+        >
+          <path d="M3.612 15.443c-.386.198-.824-.149-.746-.592l.83-4.73L.173 6.765c-.329-.314-.158-.888.283-.95l4.898-.696L7.538.792c.197-.39.73-.39.927 0l2.184 4.327 4.898.696c.441.062.612.636.282.95l-3.522 3.356.83 4.73c.078.443-.36.79-.746.592L8 13.187l-4.389 2.256z" />
+        </svg>
+      </div>
+    </div>
+  ));
+};
+
+export default LikedItem;

--- a/src/components/Liked/LikedItem.module.css
+++ b/src/components/Liked/LikedItem.module.css
@@ -1,0 +1,66 @@
+.card {
+  background-color: #ffffff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 20px;
+  text-align: left;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.07);
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 220px;
+  width: 320px;
+  position: relative;
+}
+
+.card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.title {
+  font-size: 1.2em;
+  font-weight: bold;
+  color: #333;
+  margin-top: 0;
+  margin-bottom: 10px;
+  line-height: 1.3;
+  cursor: pointer;
+}
+
+.description {
+  font-size: 0.9em;
+  color: #666;
+  line-height: 1.5;
+  margin-bottom: 15px;
+  flex-grow: 1;
+}
+
+.company {
+  display: inline-block;
+  background-color: #eef4ff; /* 태그 배경색 (이미지 기반 추정) */
+  color: #0056b3; /* 태그 글자색 */
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 0.8em;
+  font-weight: 500;
+  margin-bottom: 12px;
+}
+
+.date {
+  font-size: 0.9em;
+  color: #333;
+  line-height: 1.5;
+  margin-bottom: 15px;
+  flex-grow: 1;
+}
+
+.starContainer {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  cursor: pointer;
+  font-size: 1.2em;
+  color: #ffcc00;
+}

--- a/src/components/Liked/TabMenu.jsx
+++ b/src/components/Liked/TabMenu.jsx
@@ -1,0 +1,26 @@
+import styles from "./TabMenu.module.css";
+
+const TabMenu = ({ activeTab, onTabClick }) => {
+  return (
+    <div className={styles.tabContainer}>
+      <button
+        className={`${styles.tabButton} ${styles.firstChild} ${
+          activeTab === "emp" ? styles.active : ""
+        }`}
+        onClick={() => onTabClick("emp")}
+      >
+        채용공고
+      </button>
+      <button
+        className={`${styles.tabButton} ${styles.lastChild} ${
+          activeTab === "news" ? styles.active : ""
+        }`}
+        onClick={() => onTabClick("news")}
+      >
+        뉴스
+      </button>
+    </div>
+  );
+};
+
+export default TabMenu;

--- a/src/components/Liked/TabMenu.module.css
+++ b/src/components/Liked/TabMenu.module.css
@@ -1,0 +1,39 @@
+.tabContainer {
+  box-sizing: border-box;
+  margin-bottom: 30px;
+  display: flex;
+  justify-content: center;
+  gap: 0;
+}
+
+.tabButton {
+  padding: 10px 30px;
+  font-size: clamp(1em, 2vw, 1.1em);
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid #ccc;
+  background-color: #f9f9f9;
+  color: #555;
+  transition: background-color 0.2s, color 0.2s;
+  border-radius: 0;
+}
+
+.tabButton:first-child {
+  border-top-left-radius: 5px;
+  border-bottom-left-radius: 5px;
+}
+.tabButton:last-child {
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
+  border-left-width: 0;
+}
+
+.tabButton.active {
+  background-color: #007bff;
+  color: white;
+  border-color: #007bff;
+}
+
+.tabButton:hover:not(.active) {
+  background-color: #e9e9e9;
+}


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- 스크랩 영역 구현
-
## 🔍 작업 상세 (Implementation Details)
- 스크랩한 뉴스 출력
- 제목 클릭시 기사로 이동
- 별 클릭 시 스크랩 해제, 목록에서 사라짐
- 기사 날짜순 정렬

## 🖼️ 이미지 첨부 (Images)
- 뉴스 더미데이터로 출력 확인  
  <img src="https://github.com/user-attachments/assets/20e27ab1-6e28-41bb-a61e-474f1bec7e40" width="400" />
- 채용공고 현재 상황
 <img src="https://github.com/user-attachments/assets/232bf8db-feb7-444d-8e4f-fc5e94e8722f" width="400" />

## 📋 관련 자료 (Related Resources)
- 
## 📝 추가 정보 (Additional Information)
- 채용공고는 api 문제로 아직 출력 확인 전입니다.
- 채용공고와 뉴스는 같은 ui를 공유합니다
