### PR TITLE
[Feat(Refactor)] 헤더 완성

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,37 +1,40 @@
 /* App.css */
 
-/* #root는 전체 화면을 차지하는 기본 컨테이너 역할만 합니다. */
 #root {
-  display: flex; /* 자식 요소(AppLayout의 div)가 flex 아이템으로 동작하도록 */
-  flex-direction: column; /* 자식 요소가 수직으로 쌓이도록 */
-  min-height: 100vh; /* 최소 화면 전체 높이 */
-  width: 100%; /* 화면 전체 너비 */
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  width: 100%;
 }
 
 /* 다른 페이지들 (로그인, 회원가입 등)을 위한 기본 레이아웃 클래스 */
 .app-layout-default {
-  width: 100%; /* 부모(#root) 너비 내에서 100%를 차지하려고 시도 */
-  max-width: 1280px; /* 최대 너비 제한 */
-  margin: 0 auto;    /* max-width가 적용될 때 중앙 정렬 */
-  padding: 2rem;     /* 기존 패딩 유지 */
-  text-align: center;  /* 기존 텍스트 정렬 유지 */
-  flex-grow: 1;      /* #root 내에서 남은 수직 공간을 채우도록 */
-  display: flex;       /* 내부 컨텐츠(각 페이지 컴포넌트) 정렬을 위해 */
-  flex-direction: column; /* 내부 컨텐츠를 수직으로 쌓음 */
+  width: 100%;
+  max-width: 1280px; /* 콘텐츠 최대 너비는 유지 (선택 사항) */
+  margin: 0 auto;    /* 중앙 정렬 유지 */
+  /* padding: 2rem; */  /* 기존 전체 패딩 주석 처리 또는 원하는 값으로 변경 */
+  padding: 0 2rem;   /* 예: 상하 패딩은 없고, 좌우 패딩만 2rem 적용 */
+  /* 또는 padding: 20px; 와 같이 모든 페이지에 동일한 최소 패딩 적용 */
+  text-align: center; /* 필요에 따라 left로 변경하거나 각 페이지에서 관리 */
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
 }
 
 /* MainPage를 위한 전체 너비 레이아웃 클래스 */
 .app-layout-main {
-  width: 100%;         /* 화면 전체 너비 사용 */
-  padding: 0;          /* MainPage는 자체적으로 패딩 관리 (이전 설정 유지) */
+  width: 100%;
+  padding: 0; /* MainPage는 App.css로부터 패딩 없음 */
   margin: 0;
-  text-align: left;    /* MainPage는 왼쪽 정렬을 기본으로 */
-  flex-grow: 1;      /* #root 내에서 남은 수직 공간을 채우도록 */
-  display: flex;       /* 내부 컨텐츠(MainPage 컴포넌트) 정렬을 위해 */
-  flex-direction: column; /* 내부 컨텐츠를 수직으로 쌓음 */
+  text-align: left;
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
 }
 
-/* --- 기존 App.css의 나머지 스타일들 (.logo, .card 등) --- */
+/* --- 나머지 .logo, .card 등 스타일은 그대로 --- */
+/* ... (이전 App.css 내용) ... */
+
 .logo {
   height: 6em;
   padding: 1.5em;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,46 +1,40 @@
 import { useState, useEffect } from "react";
-// import reactLogo from './assets/react.svg'; // 사용하지 않는다면 제거 가능
-// import viteLogo from '/vite.svg'; // 사용하지 않는다면 제거 가능
-
-import './App.css'; // App.css import
+import './App.css';
 import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom';
+
 import Signup from './pages/signup';
 import Login from './pages/Login';
-import JobSearch from './pages/job_search/job_search.jsx'; // JobSearch 페이지 import 추가
-import Resetpw from './pages/Resetpw'; // 비밀번호 재설정 페이지 import
+import JobSearch from './pages/job_search/job_search.jsx';
+import Resetpw from './pages/Resetpw';
 import MainPage from './pages/MainPage/MainPage';
 import News from './pages/News/News';
+import Header from './components/Header/Header';
 
-
-
-// 라우트에 따라 다른 레이아웃 클래스를 적용하기 위한 내부 컴포넌트
-function AppLayout() {
+function PageRoutesWithLayout() {
   const location = useLocation();
-  const [layoutClass, setLayoutClass] = useState("app-layout-default"); // 기본 레이아웃
+  const [layoutClass, setLayoutClass] = useState("app-layout-default"); // 기본값
 
-  // location.pathname이 변경될 때마다 적절한 레이아웃 클래스 설정
   useEffect(() => {
-    if (location.pathname === "/") {
-      // MainPage 경로
+    const path = location.pathname;
+    if (path === '/' || path === '/news' || path === '/job_search') {
+      // MainPage, News, JobSearch는 전체 너비 레이아웃 사용
       setLayoutClass("app-layout-main");
     } else {
-      // MainPage 이외의 모든 페이지 (로그인, 회원가입, 비밀번호 재설정, 채용검색 등)
+      // 그 외 페이지들(로그인, 회원가입 등)은 기본 중앙 정렬 레이아웃 사용
       setLayoutClass("app-layout-default");
     }
-  }, [location.pathname]); // 경로가 변경될 때만 이 효과를 다시 실행
+  }, [location.pathname]);
 
   return (
-
-    // 이 div가 #root 바로 아래의 최상위 wrapper가 되어 레이아웃을 결정합니다.
     <div className={layoutClass}>
       <Routes>
         <Route path='/users/login' element={<Login/>}/>
         <Route path='/users/signup' element={<Signup/>}/>
-        <Route path='/users/reset-password' element={<Resetpw/>}/> {/* 비밀번호 재설정 라우트 */}
-        <Route path='/job_search' element={<JobSearch/>}/> {/* 채용 검색 페이지 라우트 추가 */}
+        <Route path='/users/reset-password' element={<Resetpw/>}/>
+        <Route path='/job_search' element={<JobSearch/>}/>
+        <Route path='/news' element={<News />} />
         <Route path='/' element={<MainPage/>}/>
-        <Route path='/news' element={<News/>}/>
-       </Routes>
+      </Routes>
     </div>
   );
 }
@@ -48,8 +42,8 @@ function AppLayout() {
 function App() {
   return (
     <BrowserRouter>
-      {/* AppLayout 컴포넌트를 여기서 사용해야 합니다. */}
-      <AppLayout />
+      <Header />
+      <PageRoutesWithLayout />
     </BrowserRouter>
   );
 }

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,31 +1,55 @@
 import React from 'react';
+import { Link, NavLink } from 'react-router-dom'; // NavLink 추가 (활성 링크 스타일링용)
 import styles from './Header.module.css';
+// import { UserCircle } from 'lucide-react'; // 예시: 아이콘 라이브러리 사용 시
 
 function Header() {
-    return (
-        <header className={styles.header}>
-            <div className={styles.logo}>
-                <a href="/">Logo</a> {/* TODO: 로고 이미지 또는 컴포넌트로 교체 /}
-</div>
-<nav className={styles.navigation}>
-<ul>
-<li><a href="/">홈</a></li>
-<li><a href="/news">뉴스</a></li>
-<li><a href="/jobs">채용공고</a></li>
-<li>
-<a href="/link-four">
-Link Four <span className={styles.dropdownArrow}>▼</span> {/ TODO: 실제 드롭다운 아이콘으로 교체 /}
-</a>
-{/ TODO: 드롭다운 메뉴 구현 /}
-</li>
-</ul>
-</nav>
-<div className={styles.userActions}>
-{/ TODO: 사용자 아이콘 (예: react-icons 라이브러리 사용) /}
-<span className={styles.userIcon}>👤</span> {/ 임시 사용자 아이콘 */}
-            </div>
-        </header>
-    );
+  const isLoggedIn = false; // 임시 로그인 상태
+
+  return (
+    <header className={styles.header}>
+      <div className={styles.leftSection}> {/* 로고와 주요 네비게이션을 묶는 div */}
+        <div className={styles.logo}>
+          <Link to="/">로고</Link>
+        </div>
+        <nav className={styles.navigation}>
+          <ul>
+            <li>
+              <NavLink
+                to="/news"
+                className={({ isActive }) => isActive ? `${styles.navLink} ${styles.active}` : styles.navLink}
+              >
+                뉴스
+              </NavLink>
+            </li>
+            <li>
+              <NavLink
+                to="/job_search"
+                className={({ isActive }) => isActive ? `${styles.navLink} ${styles.active}` : styles.navLink}
+              >
+                채용정보
+              </NavLink>
+            </li>
+          </ul>
+        </nav>
+      </div>
+
+      <div className={styles.userActions}>
+        {isLoggedIn ? (
+          <>
+            <span className={styles.userIcon}>
+              👤 {/* <UserCircle size={28} /> */}
+            </span>
+          </>
+        ) : (
+          <>
+            <Link to="/users/login" className={styles.authLink}>로그인</Link>
+            <Link to="/users/signup" className={`${styles.authLink} ${styles.signupButton}`}>회원가입</Link>
+          </>
+        )}
+      </div>
+    </header>
+  );
 }
 
 export default Header;

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,12 +1,20 @@
 .header {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 15px 40px; /* 상하 패딩, 좌우 패딩 (이미지 기반 추정) */
+  justify-content: space-between; /* 왼쪽 섹션과 사용자 액션을 양쪽 끝으로 분리 */
+  align-items: center; /* 수직 중앙 정렬 */
+  padding: 15px 60px;
   background-color: #ffffff;
   border-bottom: 1px solid #e0e0e0;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-  height: 60px; /* 헤더 높이 고정 (예시) */
+  height: 60px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.leftSection { /* 로고와 주요 네비게이션을 묶는 컨테이너 */
+  display: flex; /* 내부 요소들(로고, 네비게이션)을 수평으로 정렬 */
+  align-items: center; /* 수직 중앙 정렬 */
+  /* gap: 30px; */ /* 로고와 네비게이션 사이 간격은 아래에서 개별적으로 조정 */
 }
 
 .logo a {
@@ -14,35 +22,92 @@
   font-weight: bold;
   color: #333;
   text-decoration: none;
+  margin-right: 40px; /* 로고와 첫번째 네비게이션 메뉴(ul) 사이의 간격 */
+  display: flex; /* 로고 텍스트 자체의 수직 중앙 정렬을 위해 */
+  align-items: center;
+}
+
+.navigation { /* nav 태그 자체 */
+  display: flex; /* 내부 ul이 flex 아이템처럼 동작하도록 (선택적) */
+  align-items: center;
 }
 
 .navigation ul {
   list-style: none;
   padding: 0;
   margin: 0;
-  display: flex;
-  gap: 30px; /* 메뉴 간 간격 */
+  display: flex; /* li 요소들을 수평으로 정렬 */
+  align-items: center; /* 링크들을 수직 중앙 정렬 */
+  gap: 30px; /* 네비게이션 링크들(li) 사이 간격 */
 }
 
-.navigation li a {
+/* NavLink 스타일 (기존 a 태그 스타일과 유사하게) */
+.navLink {
   text-decoration: none;
   color: #555;
-  font-size: 1em;
+  font-size: 1.05em;
   font-weight: 500;
   transition: color 0.2s ease-in-out;
+  padding-bottom: 5px; /* 밑줄을 위한 공간 */
+  position: relative; /* 활성 상태 밑줄을 위한 기준점 */
 }
 
-.navigation li a:hover {
-  color: #007bff; /* 호버 시 색상 (예시) */
+.navLink:hover {
+  color: #007bff;
 }
 
-.dropdownArrow {
-  font-size: 0.7em;
-  margin-left: 4px;
+.navLink.active { /* 활성 링크 스타일 */
+  color: #007bff;
+  font-weight: bold; /* 활성 링크 굵게 (선택적) */
 }
 
-.userActions .userIcon {
-  font-size: 1.5em; /* 아이콘 크기 */
+/* 활성 링크 밑줄 효과 (선택적) */
+.navLink.active::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -2px; /* 링크 아래에 위치 */
+  width: 100%;
+  height: 2px;
+  background-color: #007bff;
+}
+
+
+.userActions {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+}
+
+.userIcon {
+  font-size: 1.6em;
   color: #555;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
+.authLink {
+  text-decoration: none;
+  color: #555;
+  font-size: 0.95em;
+  font-weight: 500;
+  padding: 8px 12px;
+  border-radius: 5px;
+  transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
+}
+
+.authLink:hover {
+  color: #007bff;
+}
+
+.signupButton {
+  background-color: #007bff;
+  color: white;
+  border: 1px solid #007bff;
+}
+
+.signupButton:hover {
+  background-color: #0056b3;
+  color: white;
 }

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -8,7 +8,6 @@ import styles from './MainPage.module.css';
 function MainPage() {
   return (
     <div className={styles.mainPageContainer}>
-      <Header />
       <main className={styles.mainContent}>
         <Weather />
         <RecommendationSection />

--- a/src/pages/MainPage/Mainpage.module.css
+++ b/src/pages/MainPage/Mainpage.module.css
@@ -1,12 +1,30 @@
-.mainPageContainer {
+/* MainPage.module.css */
+
+.mainPageContainer { /* 이 클래스에 App.jsx에서 app-layout-main이 함께 적용됨 */
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
-  background-color: #f4f6f8; /* 전체 페이지 배경색 */
+  min-height: calc(100vh - 60px); /* 헤더 높이(60px 가정)를 제외한 전체 높이 */
+  background-color: #f4f6f8;
+  width: 100%; /* app-layout-main에 의해 이미 100% */
 }
 
 .mainContent {
   flex-grow: 1;
-  width: 100%; /* 화면 너비를 채우도록 */
-  /* padding: 20px; /* 전체적인 패딩이 필요하다면 여기에, 아니면 각 섹션에서 관리 */
+  width: 100%;
+  /* 만약 MainPage 전체 콘텐츠도 최대 너비를 가지고 중앙 정렬되길 원한다면: */
+  max-width: 1280px; /* 예시 최대 너비 (App.css의 .app-layout-default와 유사하게) */
+  margin: 0 auto;   /* 중앙 정렬 */
+  padding: 0 20px;  /* 내부 콘텐츠의 좌우 여백 (상하는 각 섹션에서 관리) */
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
 }
+
+/* Weather.module.css 와 RecommendationSection.module.css 에서
+   각 섹션의 padding: 40px 5%; 등이 이 .mainContent의 padding 안에서 계산됩니다.
+   만약 .mainContent에 좌우 패딩(예: 20px)을 주었다면,
+   각 섹션의 좌우 패딩은 % 대신 고정값으로 변경하거나,
+   %를 사용하되 전체적인 너비 계산을 고려해야 할 수 있습니다.
+   가장 간단한 방법은 .mainContent에 좌우 패딩을 주고,
+   내부 섹션들은 width: 100%; padding-top, padding-bottom만 갖도록 하는 것입니다.
+*/

--- a/src/pages/News/News.jsx
+++ b/src/pages/News/News.jsx
@@ -1,12 +1,11 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 import styles from './News.module.css';
 import { fetchNews } from '../../api/news_api';
-import Header from '../../components/Header/Header';
-import Footer from '../../components/Footer/Footer';
-
-
+// import Header from '../../components/Header/Header'; // App.jsx에서 렌더링하므로 여기서 제거
+// import Footer from '../../components/Footer/Footer'; // App.jsx 또는 PageRoutesWithLayout에서 렌더링 고려
 
 const News = () => {
+  // ... (기존 state 및 useEffect 로직은 동일) ...
   const [searchTerm, setSearchTerm] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -18,16 +17,12 @@ const News = () => {
     return new Set(savedLikes ? JSON.parse(savedLikes) : []);
   });
 
-
-
-  // 뉴스 로드
   useEffect(() => {
     const getNews = async () => {
       try {
         setLoading(true);
         setError(null);
         const data = await fetchNews(searchTerm);
-        
         setNews(data.items || []);
         setDisplayedNews(data.items?.slice(0, itemsPerPage) || []);
       } catch (err) {
@@ -36,16 +31,10 @@ const News = () => {
         setLoading(false);
       }
     };
-
     getNews();
   }, [searchTerm]);
 
-
-
-  // 검색
-  const handleSearchInput = (e) => {
-    setSearchTerm(e.target.value);
-  };
+  const handleSearchInput = (e) => setSearchTerm(e.target.value);
 
   const highlightText = (text) => {
     if (!searchTerm) return text;
@@ -57,17 +46,11 @@ const News = () => {
     );
   };
 
-
-
-  // 좋아요
   const handleLikeClick = (id) => {
     setLikes(prev => {
       const newLikes = new Set(prev);
-      if (newLikes.has(id)) {
-        newLikes.delete(id);
-      } else {
-        newLikes.add(id);
-      }
+      if (newLikes.has(id)) newLikes.delete(id);
+      else newLikes.add(id);
       return newLikes;
     });
   };
@@ -76,9 +59,6 @@ const News = () => {
     localStorage.setItem('likedNews', JSON.stringify([...likes]));
   }, [likes]);
 
-
-
-  // 더보기
   const hasMore = displayedNews.length < news.length;
 
   const handleLoadMore = () => {
@@ -87,84 +67,82 @@ const News = () => {
     const newItems = news.slice(startIndex, endIndex);
     setDisplayedNews(prev => [...prev, ...newItems]);
   };
-
-  
   
   return (
+    // News.jsx의 최상위 div는 App.jsx의 layoutClass를 받음
+    // Header와 Footer는 App.jsx 또는 PageRoutesWithLayout에서 관리되므로 여기서 제거
     <div className={styles['news-container']}>
-      <Header />
+      {/* <Header /> */} {/* App.jsx에서 렌더링 */}
       
-      <div className={styles['search-container']}>
-        <input
-          type="text"
-          placeholder="뉴스 검색"
-          value={searchTerm}
-          onChange={handleSearchInput}
-          className={styles['search-input']}
-        />
-        {news.length > 0 && (
-          <div className={styles['search-results']}>
-            검색 결과: {news.length}건
-          </div>
-        )}
-      </div>
+      <div className={styles['content-wrapper']}> {/* 내부 콘텐츠를 감싸는 래퍼 */}
+        <div className={styles['search-container']}>
+          <input
+            type="text"
+            placeholder="뉴스 검색"
+            value={searchTerm}
+            onChange={handleSearchInput}
+            className={styles['search-input']}
+          />
+          {news.length > 0 && (
+            <div className={styles['search-results']}>
+              검색 결과: {news.length}건
+            </div>
+          )}
+        </div>
 
-      <div className={styles['news-list']}>
-        {loading ?
-          <div className={styles['loading']}>뉴스를 불러오는 중...</div>
-        : error ?
-          <div className={styles['error']}>{error}</div>
-        : displayedNews.length === 0 ?
-          <div className={styles['no-results']}>검색 결과가 없습니다.</div>
-        : 
-          <>
-            {displayedNews.map(item => (
-              <div key={item.id} className={styles['news-item']}>
-                <a 
-                  href={item.link}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={styles['news-content']}
-                >
-                  <h2>{highlightText(item.title)}</h2>
-                  <p>{highlightText(item.description)}</p>
-                </a>
-                <div className={styles['news-meta']}>
-                  <span className={styles['date']}>
-                    {new Date(item.pubDate).toLocaleDateString('ko-KR', {
-                      year: 'numeric',
-                      month: 'long',
-                      day: 'numeric',
-                      hour: '2-digit',
-                      minute: '2-digit'
-                    })}
-                  </span>
-                  <button 
-                    className={`${styles['like-button']} ${likes.has(item.id) ? styles['liked'] : ''}`}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      handleLikeClick(item.id);
-                    }}
+        <div className={styles['news-list']}>
+          {loading ?
+            <div className={styles['loading']}>뉴스를 불러오는 중...</div>
+          : error ?
+            <div className={styles['error']}>{error}</div>
+          : displayedNews.length === 0 ?
+            <div className={styles['no-results']}>검색 결과가 없습니다.</div>
+          : 
+            <>
+              {displayedNews.map(item => (
+                <div key={item.id} className={styles['news-item']}>
+                  <a 
+                    href={item.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles['news-content']}
                   >
-                    {likes.has(item.id) ? '★' : '☆'}
-                  </button>
+                    <h2>{highlightText(item.title)}</h2>
+                    <p>{highlightText(item.description)}</p>
+                  </a>
+                  <div className={styles['news-meta']}>
+                    <span className={styles['date']}>
+                      {new Date(item.pubDate).toLocaleDateString('ko-KR', {
+                        year: 'numeric', month: 'long', day: 'numeric',
+                        hour: '2-digit', minute: '2-digit'
+                      })}
+                    </span>
+                    <button 
+                      className={`${styles['like-button']} ${likes.has(item.id) ? styles['liked'] : ''}`}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        handleLikeClick(item.id);
+                      }}
+                    >
+                      {likes.has(item.id) ? '★' : '☆'}
+                    </button>
+                  </div>
                 </div>
-              </div>
-            ))}
-            {hasMore && (
-              <button 
-                className={styles['load-more-button']}
-                onClick={handleLoadMore}
-                disabled={loading}
-              >
-                {loading ? '로딩 중...' : '더보기'}
-              </button>
-            )}
-          </>
-        }
+              ))}
+              {hasMore && (
+                <button 
+                  className={styles['load-more-button']}
+                  onClick={handleLoadMore}
+                  disabled={loading}
+                >
+                  {loading ? '로딩 중...' : '더보기'}
+                </button>
+              )}
+            </>
+          }
+        </div>
       </div>
-
-      <Footer />
+      {/* <Footer /> */} {/* App.jsx 또는 PageRoutesWithLayout에서 렌더링 고려 */}
     </div>
   );
 };

--- a/src/pages/News/News.module.css
+++ b/src/pages/News/News.module.css
@@ -1,24 +1,32 @@
-.news-container {
-  text-align: center;
-  padding: 0;
+/* News.module.css */
+
+.news-container { /* 이 클래스가 App.jsx의 app-layout-default와 함께 적용됨 */
+  display: flex; /* MainPageContainer와 유사하게 flex로 변경 */
+  flex-direction: column; /* MainPageContainer와 유사하게 flex-direction 설정 */
   min-height: 100vh;
-  background-color: #f8fafc;
-  width: 100vw;
-  margin: 0;
-  position: absolute;
-  left: 0;
-  top: 0;
+  background-color: #f8fafc; /* 기존 배경색 유지 */
+  text-align: center; /* 기존 text-align 유지 또는 필요시 left로 변경 */
+  /* 아래 스타일들 제거 또는 수정 */
+  /* padding: 0; */ /* App.css의 app-layout-default에서 패딩을 관리하도록 하거나, 필요시 최소한의 내부 패딩 설정 */
+  /* width: 100vw; */ /* 제거 */
+  /* margin: 0; */    /* 제거 또는 필요에 따라 조정 */
+  /* position: absolute; */ /* 제거 */
+  /* left: 0; */ /* 제거 */
+  /* top: 0; */  /* 제거 */
 }
 
 .search-container {
-  margin: 30px 0;
-  padding: 0 20px;
+  margin: 30px auto; /* 좌우 auto로 중앙 정렬 시도 */
+  padding: 0 20px;   /* 내부 좌우 패딩 */
+  max-width: 700px;  /* 검색창 최대 너비 */
+  width: 100%;       /* 부모 너비에 맞춤 */
+  box-sizing: border-box;
 }
 
 .search-input {
   width: 100%;
-  max-width: 700px;
-  margin: 0 auto;
+  /* max-width는 search-container에서 제어 */
+  /* margin: 0 auto; */ /* 삭제, search-container에서 중앙 정렬 */
   position: relative;
   background: #f1f5f9;
   border-radius: 8px;
@@ -33,6 +41,7 @@
   display: flex;
   align-items: center;
   color: #1e293b;
+  box-sizing: border-box;
 }
 
 .search-input:focus {
@@ -54,11 +63,15 @@
 }
 
 .news-list {
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 0 20px;
+  max-width: 800px; /* 뉴스 목록 최대 너비 */
+  margin: 0 auto;   /* 중앙 정렬 */
+  padding: 0 20px;  /* 내부 좌우 패딩 */
+  width: 100%;
+  box-sizing: border-box;
+  flex-grow: 1; /* 푸터가 아래에 붙도록 남은 공간 채우기 */
 }
 
+/* 나머지 .news-item, .loading 등의 스타일은 기존과 거의 동일하게 유지 */
 .news-item {
   background-color: white;
   border-radius: 12px;
@@ -127,7 +140,7 @@ mark {
   color: #64748b;
 }
 
-.loading {
+.loading, .no-results {
   text-align: center;
   padding: 40px;
   font-size: 1.2rem;
@@ -135,7 +148,8 @@ mark {
   background-color: white;
   border-radius: 12px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-  margin: 20px 0;
+  margin: 20px auto; /* 중앙 정렬 */
+  max-width: 800px; /* news-list와 유사한 너비 */
 }
 
 .error {
@@ -145,18 +159,9 @@ mark {
   background-color: #fef2f2;
   border: 1px solid #fee2e2;
   border-radius: 12px;
-  margin: 20px 0;
+  margin: 20px auto; /* 중앙 정렬 */
+  max-width: 800px; /* news-list와 유사한 너비 */
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-}
-
-.no-results {
-  text-align: center;
-  padding: 40px;
-  color: #64748b;
-  background-color: white;
-  border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-  margin: 20px 0;
 }
 
 .like-button {
@@ -207,5 +212,3 @@ mark {
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(74, 144, 226, 0.2);
 }
-
-


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- 이제 모든 페이지에 헤더가 출력됩니다.
- 이ㅈㅔ 각 페이지 컴포넌트에서 헤더를 개별적으로 렌더링할 필요가 없습니다!

## 🔍 작업 상세 (Implementation Details)
- **`App.jsx` 구조 변경:**
    - `Header` 컴포넌트를 `BrowserRouter` 바로 아래, 즉 모든 페이지 라우트의 바깥으로 이동시켜 애플리케이션 전체에서 단 한 번만 렌더링되도록 수정했습니다.
    - `PageRoutesWithLayout` (또는 유사한 이름의) 내부 컴포넌트를 도입하여, 현재 URL 경로에 따라 동적으로 다른 CSS 레이아웃 클래스(`app-layout-main` 또는 `app-layout-default`)를 페이지 콘텐츠를 감싸는 `div`에 적용하도록 했습니다. 이를 통해 헤더는 레이아웃 클래스의 직접적인 영향을 받지 않고 일관된 스타일을 유지하며, 실제 페이지 콘텐츠 영역만 레이아웃 스타일의 제어를 받습니다.
- **개별 페이지 컴포넌트 수정 (예: `MainPage.jsx`, `News.jsx`):**
    - 각 페이지 컴포넌트 내부에서 개별적으로 `<Header />`를 렌더링하던 코드를 제거하여, 헤더 중복 표시 문제를 해결하고 `App.jsx`에서 중앙 관리하도록 변경했습니다.
- **`Header.jsx` 내부 개선:**
    - 네비게이션 링크의 순서를 "뉴스", "채용정보" 순으로 조정하고, 불필요해진 "홈" 버튼을 제거했습니다.
    - 페이지 이동 시 브라우저 전체가 새로고침되는 것을 방지하고 SPA(Single Page Application)의 이점을 살리기 위해, 기존 `<a>` 태그를 `react-router-dom`의 `<Link>` 또는 `<NavLink>` 컴포넌트로 교체했습니다.
- **CSS 스타일 조정 (`App.css`, `Header.module.css` 등):**
    - `App.css`에 정의된 레이아웃 클래스(`.app-layout-main`, `.app-layout-default`)가 헤더 컴포넌트의 내부 패딩이나 시각적 위치에 직접적인 영향을 주지 않도록 수정했습니다. 이제 `Header.module.css`에 정의된 헤더 고유의 스타일이 모든 페이지에서 일관되게 적용됩니다.
    - 각 페이지의 실제 콘텐츠 영역은 `App.css`의 레이아웃 클래스에 따라 적절한 패딩, 최대 너비, 정렬 등의 스타일을 적용받게 됩니다.

## 📝 추가 정보 (Additional Information)
- 로그인 상태에 따른 UI 분기: 현재 헤더 우측의 사용자 액션 영역은 임시로 "로그인", "회원가입" 링크를 표시하고 있습니다. 실제 로그인 기능 구현 시, 로그인 상태에 따라 사용자 아이콘, 마이페이지 링크, 로그아웃 버튼 등이 표시되도록 하는 로직은 아직 미완성 상태이며 추후 작업이 필요합니다.
- 로고 작업도 필요합니다.
