### PR TITLE
feat: 뉴스 찜기능 구현, fix: 뉴스 HTML 파싱 오류 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "job_weather_front",
       "version": "0.0.0",
       "dependencies": {
+        "js-cookie": "^3.0.5",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.0",
@@ -2612,6 +2613,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "js-cookie": "^3.0.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.0",

--- a/src/api/news_api.js
+++ b/src/api/news_api.js
@@ -22,7 +22,7 @@ export const fetchNews = async (searchTerm = '') => {
     const data = await response.json();
     
     const mappedItems = data.items.map(item => ({
-      id: item.newsSn,
+      newsSn: item.newsSn,
       title: item.newsTitle,
       description: item.newsDescription,
       link: item.newsLink,
@@ -36,5 +36,48 @@ export const fetchNews = async (searchTerm = '') => {
   } catch (error) {
     console.error('Error fetching news:', error);
     throw new Error('뉴스를 불러오는데 실패했습니다.');
+  }
+};
+
+// 좋아요한 뉴스 목록 조회
+export const getLikedNews = async () => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/liked`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+    });
+
+    const data = await response.json();
+    return data.map(String);
+  } catch (error) {
+    console.error('Error fetching liked news:', error);
+    throw error;
+  }
+};
+
+// 뉴스 좋아요 토글
+export const toggleLikeNews = async (newsSn) => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/like`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+      body: JSON.stringify({ newsSn: String(newsSn) })
+    });
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        throw new Error('401');
+      }
+      throw new Error('좋아요 처리에 실패했습니다.');
+    }
+  } catch (error) {
+    console.error('Error toggling like:', error);
+    throw error;
   }
 }; 

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -76,7 +76,7 @@ const Login = () => {
                                 icon: "success",
                                 draggable: true
                             });
-                             navigate("/");
+                            navigate("/");
                         } else {
                             Swal.fire({
                                 title: "로그인 실패",


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- 뉴스 찜기능 구현
- 뉴스 HTML 파싱 오류 수정

## 🔍 작업 상세 (Implementation Details)
- 뉴스 찜기능: 데이터베이스와 연결하여 사용자별 찜한 뉴스를 저장, 토글 기능으로 삭제도 가능
- 뉴스 HTML 파싱 오류 수정: 특수문자 파싱 과정에서 불필요한 문자가 추가되는 것을 안나오도록 처리

## 🖼️ 이미지 첨부 (Images)
- 찜버튼 클릭 시 효과
<img width="704" alt="좋아요 기능 데이터베이스 연결 1" src="https://github.com/user-attachments/assets/3ab8f471-a29a-49d0-9abf-ab70e3e1b57e" />

- 선택된 뉴스 데이터베이스 저장
<img width="247" alt="좋아요 기능 데이터베이스 연결 2" src="https://github.com/user-attachments/assets/9d3bd14c-9159-44af-b61d-ef852894d61a" />

- 특수문자 파싱 오류 상황
<img width="709" alt="특수문자 오류 1" src="https://github.com/user-attachments/assets/041f21cc-6b3e-4eaf-b32b-e4b05561bb20" />

- 특수문자 파싱 오류 해결
<img width="703" alt="특수문자 오류 2" src="https://github.com/user-attachments/assets/b60ac772-2926-4dce-b2f5-7338a26de9f9" />

