### PR TITLE
[Feat] 메인 페이지 기능: 날씨, 추천 뉴스 통합

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "job_weather_front",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.9.0",
         "js-cookie": "^3.0.5",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1495,6 +1496,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1581,7 +1599,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1675,6 +1692,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1794,6 +1823,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1808,7 +1846,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -1847,7 +1884,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1857,7 +1893,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1867,10 +1902,24 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2324,6 +2373,62 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2363,7 +2468,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2383,7 +2487,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2408,7 +2511,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -2448,7 +2550,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2471,8 +2572,22 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -2484,7 +2599,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2751,7 +2865,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3097,6 +3210,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.9.0",
     "js-cookie": "^3.0.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/components/JobCard/JobCard.module.css
+++ b/src/components/JobCard/JobCard.module.css
@@ -1,72 +1,83 @@
-.card {
-  background-color: #ffffff;
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
-  padding: 20px;
-  text-align: left;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.07);
-  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between; /* 내부 요소들 수직 정렬 */
-  min-height: 220px; /* 카드 최소 높이 */
+    .card {
+      background-color: #ffffff;
+      border: 1px solid #e0e0e0;
+      border-radius: 8px;
+      padding: 20px;
+      text-align: left;
+      box-shadow: 0 2px 5px rgba(0, 0, 0, 0.07);
+      transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      min-height: 220px;
+      /* 카드의 최소 높이는 유지 */
+      height: 100%;
+      /* 부모 그리드 셀의 높이를 꽉 채우도록 추가 */
+      box-sizing: border-box;
+      /* 패딩과 테두리를 높이 계산에 포함 */
+    }
 
-  /* --- 카드 너비 제어 --- */
-  width: 260px; /* 카드의 기본 너비를 지정 (기존 grid의 minmax(250px, ..) 참고) */
-  /* 또는 flex-basis 사용:
-  flex-basis: 260px;
-  flex-grow: 0;   /* 카드가 남는 공간을 차지하며 늘어나지 않도록 */
-  /* flex-shrink: 0; /* 카드가 공간이 부족할 때 줄어들지 않도록 (필요시 1로 설정하여 줄어들게 할 수도 있음) */
-  /* -------------------- */
-}
+    .card:hover {
+      transform: translateY(-5px);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    }
 
-.card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-}
+    .categoryTag {
+      display: inline-block;
+      background-color: #eef4ff;
+      color: #0056b3;
+      padding: 4px 10px;
+      border-radius: 4px;
+      font-size: 0.8em;
+      font-weight: 500;
+      margin-bottom: 12px;
+    }
 
-.categoryTag {
-  display: inline-block;
-  background-color: #eef4ff; /* 태그 배경색 (이미지 기반 추정) */
-  color: #0056b3; /* 태그 글자색 */
-  padding: 4px 10px;
-  border-radius: 4px;
-  font-size: 0.8em;
-  font-weight: 500;
-  margin-bottom: 12px;
-}
+    .title {
+      font-size: 1.2em;
+      font-weight: bold;
+      color: #333;
+      margin-top: 0;
+      margin-bottom: 10px;
+      line-height: 1.3;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
 
-.title {
-  font-size: 1.2em;
-  font-weight: bold;
-  color: #333;
-  margin-top: 0;
-  margin-bottom: 10px;
-  line-height: 1.3;
-}
+    .description {
+      font-size: 0.9em;
+      color: #666;
+      line-height: 1.5;
+      margin-bottom: 15px;
+      flex-grow: 1;
+      /* 설명 부분이 남은 공간을 채우도록 */
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      /* JobCard는 설명이 더 길 수 있으므로 3줄 유지 */
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
 
-.description {
-  font-size: 0.9em;
-  color: #666;
-  line-height: 1.5;
-  margin-bottom: 15px;
-  flex-grow: 1;
-}
+    .detailsButton {
+      background-color: transparent;
+      color: #007bff;
+      border: 1px solid #007bff;
+      padding: 8px 15px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-weight: 500;
+      font-size: 0.9em;
+      align-self: flex-start;
+      transition: background-color 0.2s, color 0.2s;
+      margin-top: auto;
+      /* 버튼을 카드 하단에 위치시키도록 추가 */
+    }
 
-.detailsButton {
-  background-color: transparent;
-  color: #007bff;
-  border: 1px solid #007bff;
-  padding: 8px 15px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-weight: 500;
-  font-size: 0.9em;
-  align-self: flex-start;
-  transition: background-color 0.2s, color 0.2s;
-}
-
-.detailsButton:hover {
-  background-color: #007bff;
-  color: white;
-}
+    .detailsButton:hover {
+      background-color: #007bff;
+      color: white;
+    }

--- a/src/components/NewsCard/NewsCard.jsx
+++ b/src/components/NewsCard/NewsCard.jsx
@@ -1,0 +1,45 @@
+// src/components/NewsCard/NewsCard.jsx
+import React from 'react';
+import styles from './NewsCard.module.css';
+
+// HTML 엔티티 디코딩 및 간단한 태그 제거 함수
+const cleanText = (htmlString) => {
+    if (!htmlString) return '';
+    const textarea = document.createElement('textarea');
+    textarea.innerHTML = htmlString; // HTML 엔티티 디코딩
+    // 간단한 태그 제거 (더 정교한 제거는 라이브러리 사용 고려)
+    let text = textarea.value;
+    text = text.replace(/<[^>]+>/g, ''); // HTML 태그 제거
+    return text;
+};
+
+
+function NewsCard({ news }) {
+  if (!news) {
+    return null;
+  }
+
+  // NewsDto의 필드명 확인: newsTitle, newsDescription, newsLink, newsDateTime
+  const title = cleanText(news.newsTitle) || "제목 없음";
+  // 설명은 일정 길이로 자르기 (예: 100자)
+  const description = news.newsDescription ? cleanText(news.newsDescription).substring(0, 100) + "..." : "내용 없음";
+  const link = news.newsLink || "#";
+  const date = news.newsDateTime ? new Date(news.newsDateTime).toLocaleDateString('ko-KR', {
+    year: 'numeric', month: 'short', day: 'numeric'
+  }) : "날짜 정보 없음";
+
+  return (
+    <a href={link} target="_blank" rel="noopener noreferrer" className={styles.cardLink}>
+      <div className={styles.card}>
+        <h4 className={styles.title}>{title}</h4>
+        <p className={styles.description}>{description}</p>
+        <div className={styles.meta}>
+          <span className={styles.date}>{date}</span>
+          {/* <span className={styles.source}>{news.source || "출처 미상"}</span> */} {/* 출처 정보가 있다면 표시 */}
+        </div>
+      </div>
+    </a>
+  );
+}
+
+export default NewsCard;

--- a/src/components/NewsCard/NewsCard.module.css
+++ b/src/components/NewsCard/NewsCard.module.css
@@ -1,0 +1,74 @@
+/* src/components/NewsCard/NewsCard.module.css */
+.cardLink {
+  text-decoration: none;
+  color: inherit;
+  display: block; /* 카드가 링크 전체 영역을 차지하도록 */
+}
+
+.card {
+  background-color: #ffffff;
+  border: 1px solid var(--border-color, #e0e0e0); /* 전역 CSS 변수 사용 예시 */
+  border-radius: var(--border-radius-base, 8px);
+  padding: 20px;
+  text-align: left;
+  box-shadow: var(--box-shadow-sm, 0 2px 5px rgba(0, 0, 0, 0.07));
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 180px; /* 뉴스 카드 최소 높이 */
+  height: 100%; /* 부모 그리드 셀 높이에 맞춤 (선택적) */
+}
+
+.card:hover {
+  transform: translateY(-5px);
+  box-shadow: var(--box-shadow-md, 0 4px 12px rgba(0, 0, 0, 0.1));
+}
+
+.title {
+  font-size: 1.1em; /* JobCard보다 약간 작게 */
+  font-weight: bold;
+  color: var(--text-color-base, #333);
+  margin-top: 0;
+  margin-bottom: 10px;
+  line-height: 1.4;
+  /* 여러 줄 말줄임 (필요시) */
+  display: -webkit-box;
+  -webkit-line-clamp: 2; /* 두 줄까지 표시 */
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-height: calc(1.1em * 1.4 * 2); /* 두 줄 높이 확보 */
+}
+
+.description {
+  font-size: 0.9em;
+  color: var(--text-color-muted, #666);
+  line-height: 1.5;
+  margin-bottom: 15px;
+  flex-grow: 1;
+  display: -webkit-box;
+  -webkit-line-clamp: 3; /* 세 줄까지 표시 */
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.8em;
+  color: var(--text-color-light, #777);
+  border-top: 1px solid var(--border-color, #e9ecef);
+  padding-top: 10px;
+  margin-top: auto; /* 메타 정보를 카드 하단에 고정 */
+}
+
+.date {
+  /* 스타일 */
+}
+
+.source {
+  /* 스타일 */
+}

--- a/src/components/RecommendationSection/RecommendationSection.jsx
+++ b/src/components/RecommendationSection/RecommendationSection.jsx
@@ -1,60 +1,125 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
 import JobCard from '../JobCard/JobCard';
-// import NewsCard from '../NewsCard/NewsCard'; // 뉴스 카드도 필요시 만듭니다.
+import NewsCard from '../NewsCard/NewsCard';
 import styles from './RecommendationSection.module.css';
 
-// 임시 데이터 (API로부터 받아올 데이터)
 const dummyJobPostings = [
   { id: 1, category: "금융권 IT", title: "IBK기업은행 체험형..", description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
   { id: 2, category: "대기업 SI", title: "삼성SDS ...", description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
   { id: 3, category: "대기업 SI", title: "CJ그룹 ...", description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
   { id: 4, category: "부트캠프", title: "LG CNS AM ...", description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
-  { id: 5, category: "금융권 IT", title: "다른 IBK 공고", description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
-  { id: 6, category: "대기업 SI", title: "다른 삼성 공고", description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
-  { id: 7, category: "대기업 SI", title: "다른 CJ 공고", description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
-  { id: 8, category: "부트캠프", title: "다른 LG 공고", description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
-  { id: 9, category: "스타트업", title: "새로운 회사 공고 1", description: "새로운 설명입니다. 다음 페이지 내용입니다." },
-  { id: 10, category: "스타트업", title: "새로운 회사 공고 2", description: "새로운 설명입니다." },
-  { id: 11, category: "중견기업", title: "새로운 회사 공고 3", description: "새로운 설명입니다." },
-  { id: 12, category: "중견기업", title: "새로운 회사 공고 4", description: "새로운 설명입니다." },
 ];
 
-// 임시 뉴스 데이터 (필요시)
-// const dummyNewsItems = [ ... ];
-
-const ITEMS_PER_PAGE = 4; // 한 페이지에 보여줄 카드 수를 4로 변경!
+const ITEMS_PER_PAGE = 4;
 
 function RecommendationSection() {
-  const [activeTab, setActiveTab] = useState('jobs'); // 'jobs' or 'news'
+  const [activeTab, setActiveTab] = useState('jobs'); // 초기 탭을 'jobs'로 설정
   const [currentPage, setCurrentPage] = useState(1);
 
-  // 현재 탭에 따라 보여줄 데이터 선택
-  const currentData = activeTab === 'jobs' ? dummyJobPostings : []; // TODO: 뉴스 데이터 추가
-  const totalPages = Math.ceil(currentData.length / ITEMS_PER_PAGE);
+  const [recommendedNews, setRecommendedNews] = useState([]);
+  const [loadingNews, setLoadingNews] = useState(false);
+  const [errorNews, setErrorNews] = useState(null);
 
-  // 현재 페이지에 보여줄 아이템들
+  const [recommendedJobs, setRecommendedJobs] = useState(dummyJobPostings);
+  const [loadingJobs, setLoadingJobs] = useState(false);
+  const [errorJobs, setErrorJobs] = useState(null);
+
+  useEffect(() => {
+    console.log("[useEffect] 현재 활성화된 탭:", activeTab);
+
+    const fetchRecommendations = async () => {
+      if (activeTab === 'news') {
+        console.log("[useEffect] 뉴스 데이터 가져오기 시도...");
+        setLoadingNews(true);
+        setErrorNews(null);
+        try {
+          console.log("[useEffect] axios.get 호출 직전. URL: http://localhost:8080/api/main/recommendations");
+          const response = await axios.get('http://localhost:8080/api/main/recommendations');
+          console.log("[useEffect] API 응답 전체:", response);
+          if (response.data && response.data.news) {
+            console.log("[useEffect] API에서 받아온 뉴스 데이터:", response.data.news);
+            setRecommendedNews(response.data.news);
+          } else {
+            console.warn("[useEffect] API 응답에 뉴스 데이터가 없거나 형식이 다릅니다:", response.data);
+            setRecommendedNews([]);
+          }
+        } catch (err) {
+          console.error("[useEffect] 추천 뉴스 로딩 실패:", err);
+          // 에러 객체의 상세 내용도 확인 (네트워크 오류, 서버 오류 등)
+          if (err.response) {
+            // 요청이 이루어졌으나 서버가 2xx 범위 외의 상태 코드로 응답한 경우
+            console.error("[useEffect] 에러 데이터:", err.response.data);
+            console.error("[useEffect] 에러 상태 코드:", err.response.status);
+          } else if (err.request) {
+            // 요청이 이루어졌으나 응답을 받지 못한 경우
+            console.error("[useEffect] 응답 없음, 요청 정보:", err.request);
+          } else {
+            // 요청을 설정하는 중에 문제가 발생한 경우
+            console.error('[useEffect] 요청 설정 오류:', err.message);
+          }
+          setErrorNews("추천 뉴스를 불러오는 데 실패했습니다.");
+          setRecommendedNews([]);
+        } finally {
+          setLoadingNews(false);
+          console.log("[useEffect] 뉴스 데이터 가져오기 완료 (로딩 상태 false).");
+        }
+      } else if (activeTab === 'jobs') {
+        console.log("[useEffect] 채용공고 데이터 설정 (현재는 더미 데이터).");
+        // TODO: 채용공고 API 연동 로직
+        setRecommendedJobs(dummyJobPostings);
+        setLoadingJobs(false); // 로딩 상태 초기화
+        setErrorJobs(null);    // 에러 상태 초기화
+      }
+    };
+
+    // activeTab이 변경될 때마다 fetchRecommendations 함수를 호출합니다.
+    // 초기 탭이 'jobs'이므로, 처음에는 채용공고 로직이 실행됩니다.
+    // '뉴스' 탭을 클릭하면 activeTab이 'news'로 바뀌고 이 useEffect가 다시 실행됩니다.
+    fetchRecommendations();
+
+  }, [activeTab]); // activeTab이 변경될 때마다 이 useEffect 훅을 다시 실행
+
+  let currentData, loadingState, errorState, CardComponent;
+  if (activeTab === 'jobs') {
+    currentData = recommendedJobs;
+    loadingState = loadingJobs;
+    errorState = errorJobs;
+    CardComponent = JobCard;
+  } else { // activeTab === 'news'
+    currentData = recommendedNews;
+    loadingState = loadingNews;
+    errorState = errorNews;
+    CardComponent = NewsCard;
+  }
+
+  const totalPages = Math.ceil(currentData.length / ITEMS_PER_PAGE);
   const paginatedData = currentData.slice(
     (currentPage - 1) * ITEMS_PER_PAGE,
     currentPage * ITEMS_PER_PAGE
   );
 
   const handleTabClick = (tabName) => {
-    setActiveTab(tabName);
-    setCurrentPage(1); // 탭 변경 시 첫 페이지로
+    console.log(tabName + " 탭 클릭됨. setActiveTab 호출 예정.");
+    setActiveTab(tabName); // 이 호출로 인해 위의 useEffect가 다시 실행됩니다.
+    setCurrentPage(1);
   };
 
-  const handlePrevPage = () => {
-    setCurrentPage((prev) => Math.max(prev - 1, 1));
-  };
+  const handlePrevPage = () => setCurrentPage((prev) => Math.max(prev - 1, 1));
+  const handleNextPage = () => setCurrentPage((prev) => Math.min(prev + 1, totalPages));
 
-  const handleNextPage = () => {
-    setCurrentPage((prev) => Math.min(prev + 1, totalPages));
-  };
+  // 렌더링 직전에 상태 값들을 확인
+  // console.log("--- 렌더링 직전 상태 ---");
+  // console.log("activeTab:", activeTab);
+  // console.log("recommendedNews:", recommendedNews);
+  // console.log("paginatedData:", paginatedData);
+  // console.log("loadingState:", loadingState);
+  // console.log("errorState:", errorState);
+  // console.log("----------------------");
 
   return (
     <section className={styles.recommendationSection}>
       <h3 className={styles.sectionTitle}>
-        {/* TODO: 사용자 이름 동적으로 변경 */}
         OOO님을 위한 소식을 확인하세요
       </h3>
       <div className={styles.tabContainer}>
@@ -72,33 +137,38 @@ function RecommendationSection() {
         </button>
       </div>
 
-      <div className={styles.contentGrid}>
-        {activeTab === 'jobs' && paginatedData.length > 0 && paginatedData.map(job => (
-          <JobCard key={job.id} job={job} />
-        ))}
-        {activeTab === 'jobs' && paginatedData.length === 0 && <p className={styles.emptyMessage}>표시할 채용 공고가 없습니다.</p>}
-        {/* TODO: 뉴스 탭 선택 시 뉴스 카드 렌더링 */}
-        {activeTab === 'news' && <p className={styles.emptyMessage}>뉴스 정보가 곧 제공될 예정입니다.</p>}
+      <div className={styles.contentDisplayArea}>
+        {loadingState && <p className={styles.loadingMessage}>데이터를 불러오는 중...</p>}
+        {!loadingState && errorState && <p className={styles.errorMessage}>{errorState}</p>}
+        {!loadingState && !errorState && paginatedData.length === 0 && (
+          <p className={styles.infoMessage}>표시할 내용이 없습니다.</p>
+        )}
+        {!loadingState && !errorState && paginatedData.length > 0 && (
+          <div className={styles.contentGrid}>
+            {paginatedData.map(item => (
+              <CardComponent
+                key={activeTab === 'jobs' ? item.id : item.newsSn}
+                {...(activeTab === 'jobs' ? { job: item } : { news: item })}
+              />
+            ))}
+          </div>
+        )}
       </div>
 
-      {currentData.length > ITEMS_PER_PAGE && (
+      {currentData.length > ITEMS_PER_PAGE && !loadingState && !errorState && (
         <div className={styles.paginationControls}>
           <div className={styles.pageIndicators}>
             {[...Array(totalPages)].map((_, index) => (
               <span
                 key={index}
                 className={`${styles.dot} ${currentPage === index + 1 ? styles.activeDot : ''}`}
-                onClick={() => setCurrentPage(index + 1)} // 점 클릭으로 페이지 이동
+                onClick={() => setCurrentPage(index + 1)}
               ></span>
             ))}
           </div>
           <div className={styles.arrowButtons}>
-            <button onClick={handlePrevPage} disabled={currentPage === 1} className={styles.arrowButton}>
-              &lt; {/* TODO: 왼쪽 화살표 아이콘 */}
-            </button>
-            <button onClick={handleNextPage} disabled={currentPage === totalPages} className={styles.arrowButton}>
-              &gt; {/* TODO: 오른쪽 화살표 아이콘 */}
-            </button>
+            <button onClick={handlePrevPage} disabled={currentPage === 1} className={styles.arrowButton}>&lt;</button>
+            <button onClick={handleNextPage} disabled={currentPage === totalPages} className={styles.arrowButton}>&gt;</button>
           </div>
         </div>
       )}

--- a/src/components/RecommendationSection/RecommendationSection.module.css
+++ b/src/components/RecommendationSection/RecommendationSection.module.css
@@ -1,21 +1,20 @@
+/* RecommendationSection.module.css */
 .recommendationSection {
   box-sizing: border-box;
-  padding: 40px 5%;
+  padding: 40px 5%; /* 좌우 패딩은 유지 */
   width: 100%;
   margin: 20px 0;
   text-align: center;
 }
 
 .sectionTitle {
-  box-sizing: border-box;
   font-size: clamp(1.5em, 3vw, 1.8em);
   font-weight: bold;
   color: #333;
-  margin-bottom: 30px;
+  margin-bottom: 20px; /* 탭과의 간격 조정 */
 }
 
 .tabContainer {
-  box-sizing: border-box;
   margin-bottom: 30px;
   display: flex;
   justify-content: center;
@@ -33,7 +32,6 @@
   transition: background-color 0.2s, color 0.2s;
   border-radius: 0;
 }
-
 .tabButton:first-child {
   border-top-left-radius: 5px;
   border-bottom-left-radius: 5px;
@@ -43,41 +41,44 @@
   border-bottom-right-radius: 5px;
   border-left-width: 0;
 }
-
 .tabButton.active {
   background-color: #007bff;
   color: white;
   border-color: #007bff;
 }
-
 .tabButton:hover:not(.active) {
   background-color: #e9e9e9;
 }
 
+.contentDisplayArea { /* 로딩/에러 메시지와 그리드를 감싸는 영역 */
+  min-height: 300px; /* 카드가 없을 때도 최소 높이 유지 (카드 min-height + gap 고려) */
+}
+
 .contentGrid {
   box-sizing: border-box;
-  display: flex; /* Grid 대신 Flexbox 사용 */
-  justify-content: center; /* 아이템들을 수평 중앙 정렬 */
-  flex-wrap: wrap; /* 화면이 매우 좁을 경우 아이템들이 다음 줄로 넘어가도록 (선택적) */
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); /* 화면 너비에 따라 컬럼 개수 자동 조절 */
   gap: 20px; /* 아이템들 사이의 간격 */
   margin-bottom: 30px;
-  padding: 0 10px; /* 좌우 약간의 여백을 주어 너무 붙지 않게 (선택적) */
-  min-height: 280px; /* 기존 최소 높이 유지 */
+  align-items: stretch; /* 그리드 아이템들이 같은 높이를 갖도록 함 (내부 컨텐츠에 따라 다를 수 있음) */
 }
 
-.emptyMessage {
-  /* grid-column: 1 / -1; /* Flexbox에서는 이 속성이 필요 없음 */
-  width: 100%; /* Flex 컨테이너 내에서 전체 너비를 차지하도록 */
-  text-align: center;
-  color: #777;
-  font-size: 1.1em;
-  padding: 50px 0;
+/* 메시지 스타일 */
+.loadingMessage,
+.errorMessage,
+.infoMessage {
   display: flex;
-  align-items: center;
   justify-content: center;
-  min-height: inherit;
+  align-items: center;
+  min-height: 200px; /* 메시지 표시 시 최소 높이 */
+  font-size: 1.1em;
+  color: #555;
+  grid-column: 1 / -1; /* 그리드 내에서 메시지가 전체 너비를 차지하도록 */
 }
+.errorMessage { color: #dc3545; }
 
+
+/* 페이지네이션 스타일 */
 .paginationControls {
   box-sizing: border-box;
   display: flex;
@@ -85,51 +86,26 @@
   align-items: center;
   margin-top: 30px;
   padding: 0 20px;
+  /* visibility: hidden; */ /* 기본적으로 숨기고, 조건부로 보이도록 JS에서 처리하거나, 아래처럼 CSS로 처리 */
 }
 
-.pageIndicators {
-  display: flex;
-  gap: 8px;
-}
+/* 데이터가 ITEMS_PER_PAGE보다 많을 때만 페이지네이션 보이도록 하는 CSS 트릭은 어려움.
+   RecommendationSection.jsx에서 조건부 렌더링 (currentData.length > ITEMS_PER_PAGE) 하는 것이 더 확실함.
+   만약 JS 로직이 정확한데도 안 보인다면, 다른 스타일에 의해 가려졌거나 display:none 된 것일 수 있음.
+*/
 
+.pageIndicators { display: flex; gap: 8px; }
 .dot {
-  width: 10px;
-  height: 10px;
-  background-color: #ccc;
-  border-radius: 50%;
-  transition: background-color 0.2s;
-  cursor: pointer;
+  width: 10px; height: 10px; background-color: #ccc;
+  border-radius: 50%; transition: background-color 0.2s; cursor: pointer;
 }
-
-.dot.activeDot {
-  background-color: #007bff;
-}
-
-.arrowButtons {
-  display: flex;
-  gap: 10px;
-}
-
+.dot.activeDot { background-color: #007bff; }
+.arrowButtons { display: flex; gap: 10px; }
 .arrowButton {
-  background-color: #fff;
-  border: 1px solid #ccc;
-  color: #333;
-  padding: 8px 12px;
-  border-radius: 50%;
-  cursor: pointer;
-  font-size: 1em;
-  line-height: 1;
-  transition: background-color 0.2s, border-color 0.2s;
-  width: 36px;
-  height: 36px;
+  background-color: #fff; border: 1px solid #ccc; color: #333;
+  padding: 8px 12px; border-radius: 50%; cursor: pointer; font-size: 1em;
+  line-height: 1; transition: background-color 0.2s, border-color 0.2s;
+  width: 36px; height: 36px;
 }
-
-.arrowButton:hover:not(:disabled) {
-  background-color: #f0f0f0;
-  border-color: #bbb;
-}
-
-.arrowButton:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
+.arrowButton:hover:not(:disabled) { background-color: #f0f0f0; border-color: #bbb; }
+.arrowButton:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/src/components/Weather/Weather.jsx
+++ b/src/components/Weather/Weather.jsx
@@ -1,37 +1,99 @@
-import React from 'react';
-import styles from './Weather.module.css';
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import styles from './Weather.module.css'; // CSS 모듈 경로
 
 function Weather() {
-  // TODO: 이 데이터는 API로부터 받아와야 합니다.
-  const weatherData = {
-    conditionText: "맑음",
-    temperature: 25, // 실제 온도가 아닌 채용 지수
-    comment1: "어제보다 4°C 높아요.",
-    comment2: "신입 개발자 채용이 00건 추가됐어요.",
-    comment3: "앞으로 화창한 날씨가 계속되길 기대해요.",
-    lastUpdated: "2025. 05. 16. 06:00" // 이미지의 업데이트 시간
+  const [weatherData, setWeatherData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchWeatherData = async () => {
+      console.log("[Weather.jsx] fetchWeatherData 호출됨");
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await axios.get('http://localhost:8080/api/weather/latest'); // 백엔드 날씨 API
+        console.log("[Weather.jsx] API 응답:", response.data);
+        if (response.data && typeof response.data.score !== 'undefined') { // score 필드가 있는지로 데이터 유효성 판단 (예시)
+          setWeatherData(response.data);
+        } else {
+          console.warn("[Weather.jsx] API 응답에 유효한 날씨 데이터가 없습니다:", response.data);
+          setError("날씨 정보를 가져왔으나, 내용이 올바르지 않습니다.");
+          setWeatherData(null); // 유효하지 않은 데이터면 null로 설정
+        }
+      } catch (err) {
+        console.error("[Weather.jsx] 날씨 정보 로딩 실패:", err);
+        setError("날씨 정보를 불러오는 데 실패했습니다. 잠시 후 다시 시도해주세요.");
+        setWeatherData(null); // 에러 발생 시 null로 설정
+      } finally {
+        setLoading(false);
+        console.log("[Weather.jsx] fetchWeatherData 완료. 로딩 상태:", false);
+      }
+    };
+
+    fetchWeatherData();
+  }, []);
+
+  if (loading) {
+    return (
+      <section className={`${styles.weatherSection} ${styles.loading}`}>
+        <p>오늘의 채용 날씨를 불러오는 중... 🌦️</p>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className={`${styles.weatherSection} ${styles.error}`}>
+        <p>{error}</p>
+      </section>
+    );
+  }
+
+  // weatherData가 null이거나, 필수 필드가 없는 경우 "정보 없음" 처리
+  if (!weatherData || typeof weatherData.score === 'undefined') {
+    return (
+      <section className={`${styles.weatherSection} ${styles.error}`}>
+        <p>표시할 날씨 정보가 없습니다.</p>
+      </section>
+    );
+  }
+
+  const getWeatherIcon = (weatherText) => {
+    if (typeof weatherText !== 'string') return "❓";
+    if (weatherText.includes("매우 맑음")) return "☀️"; // "매우 맑음" 먼저 체크
+    if (weatherText.includes("맑음")) return "☀️";
+    if (weatherText.includes("구름") || weatherText.includes("흐림")) return "🌥️";
+    if (weatherText.includes("비")) return "🌧️";
+    return "❓"; // 기본 아이콘
   };
+
+  // 백엔드 WeatherResponseDto 필드: date, score, weather, commentary
+  const displayCondition = weatherData.weather || "정보 없음";
+  const displayScore = weatherData.score; // score는 숫자 그대로 사용
+  const displayComment = weatherData.commentary || "코멘트 정보가 없습니다.";
+  // 백엔드에서 LocalDate로 오므로, 시간 정보는 없음.
+  // DB 저장 시각을 별도 필드로 받거나, 프론트에서 "기준일" 정도로만 표시
+  const displayDate = weatherData.date ? new Date(weatherData.date).toLocaleDateString('ko-KR', {
+    year: 'numeric', month: '2-digit', day: '2-digit'
+  }) : "날짜 정보 없음";
 
   return (
     <section className={styles.weatherSection}>
       <div className={styles.weatherVisual}>
-        {/* TODO: 실제 해 아이콘 (예: react-icons의 WiDaySunny) */}
-        <div className={styles.sunIcon}>☀️</div>
+        <div className={styles.sunIcon}>{getWeatherIcon(displayCondition)}</div>
         <div className={styles.temperatureBox}>
-          {weatherData.temperature}°C
+          {displayScore}점
         </div>
       </div>
       <div className={styles.weatherInfo}>
         <h2 className={styles.title}>
-          오늘의 채용 날씨는 '<span className={styles.condition}>{weatherData.conditionText}</span>' !
+          오늘의 채용 날씨는 '<span className={styles.condition}>{displayCondition}</span>' !
         </h2>
-        <ul className={styles.comments}>
-          <li>{weatherData.comment1}</li>
-          <li>{weatherData.comment2}</li>
-          <li>{weatherData.comment3}</li>
-        </ul>
+        <p className={styles.gptComment}>{displayComment}</p>
         <p className={styles.lastUpdated}>
-          업데이트 : {weatherData.lastUpdated}
+          기준일 : {displayDate}
         </p>
       </div>
     </section>


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- '오늘의 채용 날씨', '추천 뉴스' 기능을 구현하고, 통합했습니다.

## 🔍 작업 상세 (Implementation Details)
### 1. '오늘의 채용 날씨' 기능 (`feature/weather` 작업 내용 요약)

- **프론트엔드 (`Weather.jsx`):**
    - 메인 페이지 로드 시 백엔드 API를 호출하여 '오늘의 채용 날씨' 정보를 가져와 화면에 표시합니다.
    - 날씨 아이콘, 점수, 날씨 상태 텍스트, GPT 코멘트, 기준일 등을 UI에 반영했습니다.
    - 데이터 로딩 및 에러 상태 처리 로직을 포함합니다.

### 2. '추천 뉴스' 기능 (`feature/recommendation-news-2` 작업 내용 요약)

- **프론트엔드 (`RecommendationSection.jsx`, `NewsCard.jsx`):**
    - "뉴스" 탭 선택 시 백엔드의 추천 API를 호출하여 뉴스 데이터를 가져옵니다.
    - 가져온 뉴스 데이터를 `NewsCard` 컴포넌트를 사용하여 그리드 레이아웃으로 표시합니다.
    - 페이지네이션 기능을 구현하여 여러 뉴스를 나눠 볼 수 있도록 했습니다.
    - 뉴스 카드 UI(겹침 문제 해결 등) 및 로딩/에러 상태 처리를 개선했습니다.

## 🖼️ 이미지 첨부 (Images)
![image](https://github.com/user-attachments/assets/1568f2bd-660a-48d8-b84c-a6367ea192c0)
- 캡쳐상 조금 뉴스 카드 부분이 예뻐보이지 않지만, 전체화면에선 정상적으로 디스플레이됩니다.
