### PR TITLE
fix: base url를 api.js에서 중앙관리하도록 수정

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,0 +1,5 @@
+// 테스트용 baseURL
+// export const API_BASE_URL = "http://localhost:8080";
+
+// 배포용 baseURL
+export const API_BASE_URL = "https://port-0-job-weather-back-maz0osy29beb3cb3.sel4.cloudtype.app"; 

--- a/src/api/mypage_api.js
+++ b/src/api/mypage_api.js
@@ -1,5 +1,7 @@
+import { API_BASE_URL } from './api';
+
 // const MYPAGE_URL = "http://localhost:8080/mypage";
-const MYPAGE_URL = "https://port-0-job-weather-back-maz0osy29beb3cb3.sel4.cloudtype.app/mypage";
+const MYPAGE_URL = `${API_BASE_URL}/mypage`;
 
 // Mypage
 export const checkLogin = async () => {
@@ -80,7 +82,7 @@ export const unLikedItem = async (item, itemId) => {
 
 export const deleteUser = async () => {
   // const url = "http://localhost:8080/users/delete";
-  const url = "https://port-0-job-weather-back-maz0osy29beb3cb3.sel4.cloudtype.app/users/delete";
+  const url = `${API_BASE_URL}/users/delete`;
   const res = await fetch(url, {
     method: "DELETE",
     credentials: "include",

--- a/src/api/mypage_api.js
+++ b/src/api/mypage_api.js
@@ -1,4 +1,5 @@
-const MYPAGE_URL = "http://localhost:8080/mypage";
+// const MYPAGE_URL = "http://localhost:8080/mypage";
+const MYPAGE_URL = "https://port-0-job-weather-back-maz0osy29beb3cb3.sel4.cloudtype.app/mypage";
 
 // Mypage
 export const checkLogin = async () => {
@@ -78,7 +79,8 @@ export const unLikedItem = async (item, itemId) => {
 };
 
 export const deleteUser = async () => {
-  const url = "http://localhost:8080/users/delete";
+  // const url = "http://localhost:8080/users/delete";
+  const url = "https://port-0-job-weather-back-maz0osy29beb3cb3.sel4.cloudtype.app/users/delete";
   const res = await fetch(url, {
     method: "DELETE",
     credentials: "include",

--- a/src/api/news_api.js
+++ b/src/api/news_api.js
@@ -1,12 +1,13 @@
-// const API_BASE_URL = "http://localhost:8080/news";
-const API_BASE_URL = "https://port-0-job-weather-back-maz0osy29beb3cb3.sel4.cloudtype.app/news";
+import { API_BASE_URL } from './api';
+
+const NEWS_URL = `${API_BASE_URL}/news`;
 
 // 뉴스 검색
 export const fetchNews = async (searchTerm = '') => {
   try {
     const url = searchTerm 
-      ? `${API_BASE_URL}?search=${encodeURIComponent(searchTerm)}`
-      : API_BASE_URL;
+      ? `${NEWS_URL}?search=${encodeURIComponent(searchTerm)}`
+      : NEWS_URL;
 
     const response = await fetch(url, {
       method: 'GET',
@@ -43,7 +44,7 @@ export const fetchNews = async (searchTerm = '') => {
 // 좋아요한 뉴스 목록 조회
 export const getLikedNews = async () => {
   try {
-    const response = await fetch(`${API_BASE_URL}/liked`, {
+    const response = await fetch(`${NEWS_URL}/liked`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -62,7 +63,7 @@ export const getLikedNews = async () => {
 // 뉴스 좋아요 토글
 export const toggleLikeNews = async (newsSn) => {
   try {
-    const response = await fetch(`${API_BASE_URL}/like`, {
+    const response = await fetch(`${NEWS_URL}/like`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/api/news_api.js
+++ b/src/api/news_api.js
@@ -1,4 +1,5 @@
-const API_BASE_URL = "http://localhost:8080/news";
+// const API_BASE_URL = "http://localhost:8080/news";
+const API_BASE_URL = "https://port-0-job-weather-back-maz0osy29beb3cb3.sel4.cloudtype.app/news";
 
 // 뉴스 검색
 export const fetchNews = async (searchTerm = '') => {

--- a/src/api/user_api.js
+++ b/src/api/user_api.js
@@ -1,9 +1,10 @@
-// const API_BASE_URL="http://localhost:8080/users"
-const API_BASE_URL="https://port-0-job-weather-back-maz0osy29beb3cb3.sel4.cloudtype.app/users"
+import { API_BASE_URL } from './api';
+
+const USER_URL = `${API_BASE_URL}/users`;
 
 //회원가입
 export const createUser = async (json) => {
-    const url = API_BASE_URL + "/signup";
+    const url = USER_URL + "/signup";
     const res = await fetch(url,{
         method : "post",
         headers:{
@@ -14,12 +15,11 @@ export const createUser = async (json) => {
     });
     const data = await res.json();
     return data;
-
 };
 
 //닉네임 중복 여부
 export const nicknameUser = async (newNickname) =>{
-    const url = API_BASE_URL +"/nickname?nickname="+newNickname ;
+    const url = USER_URL +"/nickname?nickname="+newNickname ;
     const res = await fetch(url,{
         method : "get",
         headers:{
@@ -31,11 +31,10 @@ export const nicknameUser = async (newNickname) =>{
     return data;
 };
 
-
 //로그인
 export const userLogin = async (json) =>{
     console.log(json);
-    const url = API_BASE_URL +"/login";
+    const url = USER_URL +"/login";
     const res = await fetch(url,{
         method : "post",
         headers:{
@@ -55,7 +54,7 @@ export const userLogin = async (json) =>{
 
 //회원가입 여부
 export const emailCheck = async (newEmail) =>{
-    const url = API_BASE_URL +"/email?email="+encodeURIComponent(newEmail) ;
+    const url = USER_URL +"/email?email="+encodeURIComponent(newEmail) ;
     const res = await fetch(url,{
         method : "get",
         headers:{
@@ -70,7 +69,7 @@ export const emailCheck = async (newEmail) =>{
 //비밀번호 재설정
 export const resetPassWord = async (json) => {
     console.log(json);
-    const url = API_BASE_URL + "/reset-password";
+    const url = USER_URL + "/reset-password";
     const res = await fetch(url,{
         method : "post",
         headers:{
@@ -81,5 +80,4 @@ export const resetPassWord = async (json) => {
     });
     const data = await res.json();
     return data;
-
 };

--- a/src/api/user_api.js
+++ b/src/api/user_api.js
@@ -1,4 +1,5 @@
-const API_BASE_URL="http://localhost:8080/users"
+// const API_BASE_URL="http://localhost:8080/users"
+const API_BASE_URL="https://port-0-job-weather-back-maz0osy29beb3cb3.sel4.cloudtype.app/users"
 
 //회원가입
 export const createUser = async (json) => {

--- a/src/components/Alarm/NotificationList.jsx
+++ b/src/components/Alarm/NotificationList.jsx
@@ -11,7 +11,8 @@ function NotificationList({ page, setPage }) {
 
   //  백엔드에서 사용자 맞춤 알림 불러오기
   useEffect(() => {
-    axios.post('http://localhost:8080/api/notifications/user-matching', {userSn:7}, { withCredentials: true })
+    // axios.post('http://localhost:8080/api/notifications/user-matching', {userSn:7}, { withCredentials: true })
+    axios.post('https://port-0-job-weather-back-maz0osy29beb3cb3.sel4.cloudtype.app/api/notifications/user-matching', {userSn:7}, { withCredentials: true })
     //유저 매칭을 부르는데 어떤 사용자를 가져올지...
       .then((res) => {
         // 받은 데이터를 최신순 정렬 (옵션)

--- a/src/components/Alarm/NotificationList.jsx
+++ b/src/components/Alarm/NotificationList.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import NotificationItem from './NotificationItem';
+import { API_BASE_URL } from '../../api/api';
 
 function NotificationList({ page, setPage }) {
   const itemsPerPage = 4;
@@ -11,9 +12,7 @@ function NotificationList({ page, setPage }) {
 
   //  백엔드에서 사용자 맞춤 알림 불러오기
   useEffect(() => {
-    // axios.post('http://localhost:8080/api/notifications/user-matching', {userSn:7}, { withCredentials: true })
-    axios.post('https://port-0-job-weather-back-maz0osy29beb3cb3.sel4.cloudtype.app/api/notifications/user-matching', {userSn:7}, { withCredentials: true })
-    //유저 매칭을 부르는데 어떤 사용자를 가져올지...
+    axios.post(`${API_BASE_URL}/api/notifications/user-matching`, {userSn:7}, { withCredentials: true })
       .then((res) => {
         // 받은 데이터를 최신순 정렬 (옵션)
         const sorted = res.data.sort((a, b) => b.id - a.id);

--- a/src/components/RecommendationSection/RecommendationSection.jsx
+++ b/src/components/RecommendationSection/RecommendationSection.jsx
@@ -36,8 +36,10 @@ function RecommendationSection() {
         setLoadingNews(true);
         setErrorNews(null);
         try {
-          console.log("[useEffect] axios.get 호출 직전. URL: http://localhost:8080/api/main/recommendations");
-          const response = await axios.get('http://localhost:8080/api/main/recommendations');
+          // console.log("[useEffect] axios.get 호출 직전. URL: http://localhost:8080/api/main/recommendations");
+          // const response = await axios.get('http://localhost:8080/api/main/recommendations');
+          console.log("[useEffect] axios.get 호출 직전. URL: https://port-0-job-weather-back-maz0osy29beb3cb3.sel4.cloudtype.app/api/main/recommendations");
+          const response = await axios.get('https://port-0-job-weather-back-maz0osy29beb3cb3.sel4.cloudtype.app/api/main/recommendations');
           console.log("[useEffect] API 응답 전체:", response);
           if (response.data && response.data.news) {
             console.log("[useEffect] API에서 받아온 뉴스 데이터:", response.data.news);

--- a/src/components/RecommendationSection/RecommendationSection.jsx
+++ b/src/components/RecommendationSection/RecommendationSection.jsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import JobCard from '../JobCard/JobCard';
 import NewsCard from '../NewsCard/NewsCard';
 import styles from './RecommendationSection.module.css';
+import { API_BASE_URL } from '../../api/api';
 
 // 채용공고 탭에 표시할 고정된 더미 데이터 (4개)
 const fixedDummyJobs = [
@@ -36,10 +37,8 @@ function RecommendationSection() {
         setLoadingNews(true);
         setErrorNews(null);
         try {
-          // console.log("[useEffect] axios.get 호출 직전. URL: http://localhost:8080/api/main/recommendations");
-          // const response = await axios.get('http://localhost:8080/api/main/recommendations');
-          console.log("[useEffect] axios.get 호출 직전. URL: https://port-0-job-weather-back-maz0osy29beb3cb3.sel4.cloudtype.app/api/main/recommendations");
-          const response = await axios.get('https://port-0-job-weather-back-maz0osy29beb3cb3.sel4.cloudtype.app/api/main/recommendations');
+          console.log("[useEffect] axios.get 호출 직전. URL:", `${API_BASE_URL}/api/main/recommendations`);
+          const response = await axios.get(`${API_BASE_URL}/api/main/recommendations`);
           console.log("[useEffect] API 응답 전체:", response);
           if (response.data && response.data.news) {
             console.log("[useEffect] API에서 받아온 뉴스 데이터:", response.data.news);

--- a/src/components/Weather/Weather.jsx
+++ b/src/components/Weather/Weather.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import styles from './Weather.module.css'; // CSS 모듈 경로
+import { API_BASE_URL } from '../../api/api';
 
 function Weather() {
   const [weatherData, setWeatherData] = useState(null);
@@ -13,8 +14,7 @@ function Weather() {
       try {
         setLoading(true);
         setError(null);
-        // const response = await axios.get('http://localhost:8080/api/weather/latest'); // 백엔드 날씨 API
-        const response = await axios.get('https://port-0-job-weather-back-maz0osy29beb3cb3.sel4.cloudtype.app/api/weather/latest'); // 백엔드 날씨 API
+        const response = await axios.get(`${API_BASE_URL}/api/weather/latest`);
         console.log("[Weather.jsx] API 응답:", response.data);
         if (response.data && typeof response.data.score !== 'undefined') { // score 필드가 있는지로 데이터 유효성 판단 (예시)
           setWeatherData(response.data);

--- a/src/components/Weather/Weather.jsx
+++ b/src/components/Weather/Weather.jsx
@@ -13,7 +13,8 @@ function Weather() {
       try {
         setLoading(true);
         setError(null);
-        const response = await axios.get('http://localhost:8080/api/weather/latest'); // 백엔드 날씨 API
+        // const response = await axios.get('http://localhost:8080/api/weather/latest'); // 백엔드 날씨 API
+        const response = await axios.get('https://port-0-job-weather-back-maz0osy29beb3cb3.sel4.cloudtype.app/api/weather/latest'); // 백엔드 날씨 API
         console.log("[Weather.jsx] API 응답:", response.data);
         if (response.data && typeof response.data.score !== 'undefined') { // score 필드가 있는지로 데이터 유효성 판단 (예시)
           setWeatherData(response.data);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { API_BASE_URL } from './src/api/api'
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -7,7 +8,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        target: API_BASE_URL,
         changeOrigin: true,
       },
     }


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- base url을 api.js에서  중앙관리

## 🔍 작업 상세 (Implementation Details)
- 하드 코딩된 base url을 api.js에서 중앙관리하고 변수로 사용
- 수정된 페이지
- new file:   src/api/api.js
- modified:   src/api/mypage_api.js
- modified:   src/api/news_api.js
- modified:   src/api/user_api.js
- modified:   src/components/Alarm/NotificationList.jsx
- modified:   src/components/RecommendationSection/RecommendationSection.jsx
- modified:   src/components/Weather/Weather.jsx
- modified:   vite.config.js

## 📝 추가 정보 (Additional Information)
- 사용법: 
- base url을 임폴트한다: import { API_BASE_URL } from './api'; 
- API_BASE_URL을 변수처럼 사용: 예) const MYPAGE_URL = `${API_BASE_URL}/mypage`;
